### PR TITLE
Fix compatibility to kernel 7.0.10

### DIFF
--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -9575,7 +9575,7 @@ static int hidpp10_consumer_keys_raw_event(struct hidpp_device *hidpp,
 	memcpy(&consumer_report[1], &data[3], 4);
 	/* We are called from atomic context */
 	hid_report_raw_event(hidpp->hid_dev, HID_INPUT_REPORT,
-			     consumer_report, 5, 1);
+			     consumer_report, 5, 1, 0);
 
 	return 1;
 }


### PR DESCRIPTION
Building the current master branch on CachyOS with the latest kernel led to the following error:

```
hid-logitech-hidpp.c:9578:30: error: too few arguments to function call, expected 6, have 5
 9577 |         hid_report_raw_event(hidpp->hid_dev, HID_INPUT_REPORT,
      |         ~~~~~~~~~~~~~~~~~~~~
 9578 |                              consumer_report, 5, 1);
      |                                                   ^
/usr/lib/modules/7.0.10-2-cachyos/build/include/linux/hid.h:1275:5: note: 'hid_report_raw_event' declared here
 1275 | int hid_report_raw_event(struct hid_device *hid, enum hid_report_type type, u8 *data,
      |     ^                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1276 |                          size_t bufsize, u32 size, int interrupt);
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This was due to a new parameter for interrupts being added as a sixth parameter. Since this is a simple consumer report, we do not need an interrupt I think.