### PR TITLE
hidpp: DD-wheel correctness batch (pedal init #30, damping/TF reads, sensitivity, rev-lights)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,9 +22,6 @@ on:
         description: "Existing release tag to (re)publish, e.g. v0.12.1"
         required: true
 
-permissions:
-  contents: write
-
 env:
   # tag name for either trigger; strip the leading v for the bare version
   TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
@@ -50,6 +47,9 @@ jobs:
     name: Debian/Ubuntu .deb
     needs: validate
     runs-on: ubuntu-latest
+    # Only this job needs write access, to attach the .deb to the release.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/PROTOCOL_SPECIFICATION.md
+++ b/docs/PROTOCOL_SPECIFICATION.md
@@ -258,7 +258,13 @@ Offset  Size  Description
 
 Example: `05 07 00 00 00 00 00 FF FF 00 00 00 00 ...`
 
-This command appears to refresh/maintain FFB state during gameplay.
+> **CORRECTION (capture re-analysis):** this `05 07` packet is NOT a wheel
+> command. In every capture the `05 07 .. FF FF` packets are 32-byte
+> DualShock-4 lightbar/rumble output reports to a *game controller* that was
+> plugged in at capture time - the `FF FF` is the DS4 lightbar colour, not an
+> FFB value. G HUB never sends `05 07` to the wheel, and the wheel's FFB
+> endpoint is silent at idle. Host-alive is carried entirely by the type-0x01
+> force stream. The driver no longer sends this packet.
 
 ### Example FFB Commands
 
@@ -275,12 +281,14 @@ Maximum force RIGHT, sequence 0x01:
 
 ### Observed Behavior
 
-- Force update rate: games stream 250-1000 Hz (AC EVO at the top end);
-  the kernel driver's own force stream runs at 500 Hz, rising to a
-  unified force+audio packet per tick while a texture effect plays
-- Sequence counter increments with each command
+- Force update rate: games stream **1000 Hz** (observed in every gameplay
+  capture: ACC on RS50, ACC/BeamNG on G PRO - median inter-packet gap
+  ~1.0 ms); the kernel driver's own force stream currently runs at 500 Hz
+- Sequence counter increments with each command (one shared counter across
+  all interface-2 packet types on the wire)
 - Force value and duplicate must always match
-- `05 07` command sent periodically (~3 times per minute)
+- `05 07` is NOT sent to the wheel (see the correction above - it is a
+  DualShock-4 packet); there is no idle FFB keepalive
 
 ---
 
@@ -368,7 +376,7 @@ Device → Host: Interrupt IN (endpoint 0x82)
 | 0x03 | `0x0005` | DeviceNameType | Device name string (fn0 = length, fn1 = name at offset, fn2 = type) |
 | 0x04 | `0x00C3` | SecureDFU | Firmware update |
 | **0x09** | **`0x1BC0`** | **ReportHidUsages** | Enables extra Button-page HID usages; optional (see 5.1) |
-| 0x0A | `0x8040` | Brightness/Sensitivity | Sensitivity (desktop) + **Brightness** (onboard) |
+| 0x0A | `0x8040` | Brightness | **LED brightness only** (both modes). The steering "Sensitivity" slider is a `0x80A4` response-curve upload, NOT this feature (see below) |
 | **0x0B** | **`0x807A`** | **LIGHTSYNC** | LED effect mode selection |
 | **0x0C** | **`0x807B`** | **RGBZoneConfig** | LED RGB color data (see Section 9) |
 | 0x0D | `0x80A4` | AxisResponseCurve | Per-axis 64-point response curves (see 5.1) |
@@ -415,7 +423,7 @@ x8040 gained its illumination on/off functions in v1.)
 
 ### Setting Commands (All Verified)
 
-Each setting feature exposes a handful of HID++ functions. The encoding in byte 3 of the short report is `(function_number << 4) | SW_ID`. In the G Hub captures this analysis is derived from, SW_ID is `0xD` across the board; the Linux driver uses its own SW_ID `0x01`, so the same SET appears on the wire as e.g. `0x21` rather than `0x2D`. GET semantics are stable across settings (`fn=0` queries capabilities/limits, `fn=1` reads current value) but the SET function number varies **per feature and per wheel**. Do not assume all settings use `fn=2`: damping and TRUEFORCE each have their own SET fn, and the two wheels agree on the exceptions.
+Each setting feature exposes a handful of HID++ functions. The encoding in byte 3 of the short report is `(function_number << 4) | SW_ID`. In the G Hub captures this analysis is derived from, SW_ID is `0xD` across the board; the Linux driver uses SW_ID `0x0a` (it must not use `0x01` - the pedal sub-device's MCU silently drops sw-id `0x01`), so the same SET appears on the wire as e.g. `0x2a` rather than `0x2d`. GET semantics are *mostly* `fn=0` queries capabilities/limits and `fn=1` reads current value - **but damping is an exception: its current value is read with `fn=0`; `fn=1` is the SETTER and an empty-payload `fn=1` sets damping to 0.** The SET function number also varies **per feature and per wheel**. Do not assume all settings use `fn=2`: damping and TRUEFORCE each have their own SET fn, and the two wheels agree on the exceptions.
 
 | Feature | Page | GET caps | GET value | SET (RS50 + G Pro) |
 |---------|------|----------|-----------|--------------------|
@@ -543,7 +551,17 @@ Set: 10 FF 15 2D [Value_Hi] [Value_Lo] 00
 > ⚠️ **Note**: This setting is ONLY available in Onboard mode (profiles 1-5).
 > It is NOT available in Desktop mode (profile 0).
 
-#### Sensitivity (Feature 0x8040, Index 0x0A) - DESKTOP MODE ONLY
+#### Sensitivity - it is a 0x80A4 response curve, NOT 0x8040
+
+> **CORRECTION (capture re-analysis + hardware):** the steering "Sensitivity"
+> slider does NOT write feature 0x8040. `0x8040` is LED BrightnessControl only.
+> G HUB's Sensitivity is a full 64-point `0x80A4` AxisResponseCurve upload on
+> the steering axis (a cubic Bezier (0,0)->(1,1) with control points
+> P1=(1-s, s), P2=(s, 1-s) for s=slider/100; 50 = identity = revert to the
+> built-in curve). The `0x8040` "Set" shown below only changes LED brightness.
+> The driver's `wheel_sensitivity` now uploads the 0x80A4 curve accordingly.
+
+The 0x8040 write shown here changes LED brightness (both modes):
 ```
 Set: 10 FF 0A 2D 00 [Value] 00
 ```

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -6632,6 +6632,25 @@ static int hidpp_dd_ff_raw_hidpp_event(struct hidpp_device *hidpp, u8 *data,
 	}
 
 	/*
+	 * OLED-side settings edit: on the RS50 the wheel signals a profile or
+	 * settings change made at its own OLED by broadcasting on the Profile
+	 * feature (0x8137) itself - fn0, sw_id 0 (e.g. `12 ff 17 00 01 01 ...`)
+	 * - NOT on 0x80D0 (which the G Pro uses for profile broadcasts). Without
+	 * this, cached settings (strength/damping/filter/TF edited at the OLED)
+	 * go stale until the next profile switch. Our own 0x8137 GET/getInfo
+	 * responses are matched and consumed by the sync path before reaching
+	 * here, so this only fires on genuine unsolicited broadcasts.
+	 */
+	if (ff->idx_profile != HIDPP_DD_FEATURE_NOT_FOUND &&
+	    data[2] == ff->idx_profile &&
+	    data[3] == 0x00) {
+		dd_info(hidpp->hid_dev,
+			 "OLED settings-edit broadcast -> re-querying settings\n");
+		queue_work(ff->wq, &ff->settings_refresh_work);
+		return 1;
+	}
+
+	/*
 	 * Rotation-changed: <rep> <dev> <idx_range> <fn|sw=0> <hi> <lo> ...
 	 *
 	 * Same sw_id==0 unsolicited-broadcast gate as the profile handler
@@ -8213,9 +8232,12 @@ static ssize_t wheel_damping_store(struct device *dev, struct device_attribute *
 	value = (damping * 65535) / 100;
 
 	if (ff->idx_damping == HIDPP_DD_FEATURE_NOT_FOUND) {
-		/* Compat-mode fallback: best-guess feature 0x8137 / fallback
-		 * index 0x15 fn 2. See docs/HIDPP_DD_PROTOCOL_SPECIFICATION.md
-		 * section 5.1. */
+		/*
+		 * Compat mode: hidpp_dd_compat_set_damping() resolves the
+		 * damping feature 0x8133 (verified fallback index 0x14, fn1).
+		 * (The old comment here cited a disproven guess - 0x8137 is the
+		 * Profile feature, not damping.)
+		 */
 		ret = hidpp_dd_compat_set_damping(hidpp, ff, value);
 		if (ret)
 			return ret;

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -7539,12 +7539,21 @@ static void hidpp_dd_ff_init_work(struct work_struct *work)
 	 * Windows G Hub confirm it's sent successfully. The Linux HID layer
 	 * should pass through undeclared report IDs without issue.
 	 */
-	/* Send refresh immediately, then schedule periodic refreshes */
-	queue_delayed_work(ff->wq, &ff->refresh_work, 0);
+	/*
+	 * The wheel needs NO periodic 05-07 keepalive. G HUB never sends 05 07
+	 * to the wheel - in the captures those are 32-byte DualShock-4 lightbar
+	 * packets to a controller that was plugged in at the time - and G HUB's
+	 * interface-2 endpoint is silent at idle. Host-alive is carried by the
+	 * type-01 FFB stream. refresh_work (a 64-byte 05-07 every 20 s) is
+	 * therefore no longer queued; it is left dormant (not deleted) pending
+	 * feel-test confirmation that FFB persists across idle without it,
+	 * after which the work item and its plumbing can be removed outright.
+	 *
+	 * range_poll_work below is unrelated (it detects a game SDK's
+	 * launch-time rotation-range reset) and stays.
+	 */
 	queue_delayed_work(system_unbound_wq, &ff->range_poll_work,
 			   msecs_to_jiffies(HIDPP_DD_FF_REFRESH_INTERVAL_MS));
-	dd_info(hid, "FFB refresh command queued (then every %dms)\n",
-		HIDPP_DD_FF_REFRESH_INTERVAL_MS);
 
 	/*
 	 * Effect timer is started on-demand when effects play.
@@ -9749,43 +9758,62 @@ static DEVICE_ATTR(wheel_led_effect, 0664, wheel_led_effect_show, wheel_led_effe
  */
 #define HIDPP_DD_REV_SWID		0x0d	/* G HUB's sw-id, kept verbatim */
 #define HIDPP_DD_REV_MAX_LEVEL		10
-#define HIDPP_DD_REV_MIN_GAP_MS		160	/* G HUB's observed cadence */
+#define HIDPP_DD_REV_MIN_GAP_MS		10	/* ~100 Hz. G HUB drives rev lights at ~127 Hz (~7.5 ms per pair); the old 160 ms was a misread and made a full 0->10 sweep take ~1.6 s. */
 #define HIDPP_DD_REV_ARM_GAP_MS	4
 
 static int hidpp_dd_rev_send_short(struct hidpp_device *hidpp, u8 idx, u8 fn,
 				   u8 p0)
 {
-	struct hidpp_report report = {
-		.report_id = REPORT_ID_HIDPP_SHORT,
-		.device_index = 0xff,
-		.fap = {
-			.feature_index = idx,
-			.funcindex_clientid = (fn << 4) | HIDPP_DD_REV_SWID,
-			.params = { p0, 0, 0 },
-		},
-	};
+	struct hidpp_report *report;
+	int ret;
 
-	return __hidpp_send_report(hidpp->hid_dev, &report);
+	/*
+	 * DMA-safe buffer: __hidpp_send_report() can hand this straight to a
+	 * USB interrupt-OUT URB (on FORCE_OUTPUT_REPORTS wheels), and a stack
+	 * buffer is not DMA-mappable - it WARNs in usb_hcd_map_urb_for_dma and
+	 * the send fails with -EIO. Seen live on the RS50 the first time the
+	 * rev-light path was exercised (it had only ever been gated on to the
+	 * untested G PRO before). Mirrors hidpp_dd_ff_refresh_work's kzalloc.
+	 */
+	report = kzalloc(sizeof(*report), GFP_KERNEL);
+	if (!report)
+		return -ENOMEM;
+	report->report_id = REPORT_ID_HIDPP_SHORT;
+	report->device_index = 0xff;
+	report->fap.feature_index = idx;
+	report->fap.funcindex_clientid = (fn << 4) | HIDPP_DD_REV_SWID;
+	report->fap.params[0] = p0;
+	ret = __hidpp_send_report(hidpp->hid_dev, report);
+	kfree(report);
+	return ret;
 }
 
 static int hidpp_dd_rev_send_level(struct hidpp_device *hidpp, u8 idx, u8 level)
 {
-	struct hidpp_report report = {
-		.report_id = REPORT_ID_HIDPP_LONG,
-		.device_index = 0xff,
-		.fap = {
-			.feature_index = idx,
-			.funcindex_clientid = (6 << 4) | HIDPP_DD_REV_SWID,
-			/* params start at report byte 4: 00 01 00 0a 00 LL */
-			.params = { 0x00, 0x01, 0x00, 0x0a, 0x00, level },
-		},
-	};
+	struct hidpp_report *report;
 	int ret;
 
 	ret = hidpp_dd_rev_send_short(hidpp, idx, 2, 0);
 	if (ret < 0)
 		return ret;
-	return __hidpp_send_report(hidpp->hid_dev, &report);
+
+	report = kzalloc(sizeof(*report), GFP_KERNEL);	/* DMA-safe, see above */
+	if (!report)
+		return -ENOMEM;
+	report->report_id = REPORT_ID_HIDPP_LONG;
+	report->device_index = 0xff;
+	report->fap.feature_index = idx;
+	report->fap.funcindex_clientid = (6 << 4) | HIDPP_DD_REV_SWID;
+	/* params start at report byte 4: 00 01 00 0a 00 LL */
+	report->fap.params[0] = 0x00;
+	report->fap.params[1] = 0x01;
+	report->fap.params[2] = 0x00;
+	report->fap.params[3] = 0x0a;
+	report->fap.params[4] = 0x00;
+	report->fap.params[5] = level;
+	ret = __hidpp_send_report(hidpp->hid_dev, report);
+	kfree(report);
+	return ret;
 }
 
 /*
@@ -11616,8 +11644,15 @@ static umode_t hidpp_dd_wheel_group_is_visible(struct kobject *kobj,
 	struct hid_device *hid = to_hid_device(dev);
 	bool real_gpro = dd_is_real_gpro(hid);
 
+	/*
+	 * Rev-lights use the same 0x807A level protocol on both the RS50
+	 * (10-LED faceplate strip) and the G PRO rim - G HUB captures show the
+	 * identical arm-burst + level pairs on RS50 native, so expose the
+	 * attribute on both. The store gates on the LIGHTSYNC feature at
+	 * runtime; a wheel without it returns -EOPNOTSUPP.
+	 */
 	if (attr == &dev_attr_wheel_rev_level.attr)
-		return real_gpro ? attr->mode : 0;
+		return attr->mode;
 
 	/*
 	 * Hide every wheel_led_* LIGHTSYNC attribute on a real G PRO by

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -179,8 +179,22 @@ module_param(inject_pid, uint, 0644);
 MODULE_PARM_DESC(inject_pid,
 	"PID injection on interface 0 of direct-drive (RS50/G PRO) wheels: 0=off (default), 1=dry-run (log only), 2=actuate (drive the wheel).");
 
-/* Define a non-zero software ID to identify our own requests */
-#define LINUX_KERNEL_SW_ID			0x01
+/*
+ * HID++ software-id OR'd into every request's funcindex_clientid.
+ *
+ * Upstream hid-logitech-hidpp uses 0x01. The RS50 / G PRO PEDAL unit, however,
+ * is a separate MCU bridged by the wheel base at HID++ device index 0x02, and
+ * its firmware SILENTLY DROPS every request carrying software-id 0x01 - it
+ * sends no answer at all, not even a HID++ error. Verified live by sweeping the
+ * id against the pedal's getFeature(0x80A4): 0x02, 0x05, 0x0a and 0x0f are all
+ * answered, only 0x01 gets total silence; meanwhile the base (0xff) and motor
+ * (0x05) answer any id including 0x01. Our old 0x01 therefore made every pedal
+ * query (e.g. the 0x80A4 response-curve probe in discover_settings_features)
+ * time out, and the retry loop turned that into a 15-20 s init stall (issue
+ * #30). G HUB uses 0x0a; we match it so the pedal answers on the first try.
+ * The base and motor are unaffected by the change.
+ */
+#define LINUX_KERNEL_SW_ID			0x0a
 
 #define REPORT_ID_HIDPP_SHORT			0x10
 #define REPORT_ID_HIDPP_LONG			0x11

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -564,6 +564,18 @@ static int hidpp_send_message_sync(struct hidpp_device *hidpp,
 
 	do {
 		ret = __do_hidpp_send_message_sync(hidpp, message, response);
+		/*
+		 * A transport failure (ret < 0, e.g. -ETIMEDOUT: the device
+		 * sent no answer) memsets `response`, so the report_id-keyed
+		 * BUSY checks below would never break and we would retry a dead
+		 * query up to 3x - each a full 5s timeout, all while holding
+		 * send_mutex. That is what turned one silent query into a
+		 * 15-20s init stall and blocked every other HID++ user behind
+		 * it. Retrying only helps for an explicit HID++ BUSY error;
+		 * bail out immediately on any transport error.
+		 */
+		if (ret < 0)
+			break;
 		if (response->report_id == REPORT_ID_HIDPP_SHORT &&
 		    ret != HIDPP_ERROR_BUSY)
 			break;
@@ -791,13 +803,20 @@ static inline bool hidpp_match_answer(struct hidpp_device *hidpp,
 		return false;
 
 	/*
-	 * Some devices (e.g., the direct-drive wheels) don't echo back the software
-	 * ID in the response's funcindex_clientid field - they only return
-	 * the function index in the upper nibble, leaving the lower nibble
-	 * as 0. Handle this by only comparing the function index (upper nibble)
-	 * when the response's SW_ID is 0.
+	 * The direct-drive wheels don't echo back the software ID - they return
+	 * only the function index in the upper nibble, leaving the lower nibble
+	 * 0 - so for them we compare the function nibble only when the answer's
+	 * SW_ID is 0.
+	 *
+	 * Gate this leniency on the DD quirk, exactly like the device-index
+	 * check above. Only the DD wheels zero the SW_ID; for any other
+	 * Logitech device an unsolicited SW_ID-0 event/broadcast that happens
+	 * to share a pending question's feature index and function nibble would
+	 * otherwise be mistaken for its answer. Others keep upstream-strict
+	 * matching (full funcindex_clientid compare below).
 	 */
-	if ((answer->fap.funcindex_clientid & 0x0f) == 0) {
+	if ((hidpp->quirks & HIDPP_QUIRK_DD_FFB) &&
+	    (answer->fap.funcindex_clientid & 0x0f) == 0) {
 		/* Device didn't echo SW_ID - compare function ID only */
 		return (answer->fap.feature_index == question->fap.feature_index) &&
 		       ((answer->fap.funcindex_clientid & 0xf0) ==
@@ -5470,8 +5489,16 @@ static void hidpp_dd_ff_send_force(struct hidpp_dd_ff_data *ff, s32 force)
 		return;
 
 	pending = atomic_read(&ff->pending_work);
-	if (pending >= HIDPP_DD_FF_MAX_PENDING_WORK)
+	if (pending >= HIDPP_DD_FF_MAX_PENDING_WORK) {
+		/*
+		 * Queue saturated - the USB link is likely stalled. Count the
+		 * drop like the kmalloc-failure path below (this is the more
+		 * likely drop under a stalled link), otherwise sustained
+		 * saturation silently evaporates forces with no dmesg trace.
+		 */
+		ff->err_count++;
 		return;
+	}
 
 	ff_work = kmalloc(sizeof(*ff_work), GFP_ATOMIC);
 	if (!ff_work) {
@@ -5705,7 +5732,10 @@ static void hidpp_dd_tf_init_work_handler(struct work_struct *work)
 			pkt[HIDPP_DD_TF_INIT_SEQ_OFFSET] = seq++;
 			ret = hid_hw_output_report(hdev, pkt,
 						   HIDPP_DD_FF_REPORT_SIZE);
-			if (ret < 0 && ret != -EIO && ret != -ENODEV)
+			/* Only -ENOSYS means ->output_report is unimplemented;
+			 * fall back to raw_request then. Real transport errors
+			 * must surface, not get re-sent as a control transfer. */
+			if (ret == -ENOSYS)
 				ret = hid_hw_raw_request(hdev,
 						HIDPP_DD_FF_REPORT_ID, pkt,
 						HIDPP_DD_FF_REPORT_SIZE,
@@ -6147,8 +6177,13 @@ static void hidpp_dd_ff_work_handler(struct work_struct *work)
 	 * This mirrors what hidraw does in hidraw_write().
 	 */
 	ret = hid_hw_output_report(hdev, ff_work->report_buf, HIDPP_DD_FF_REPORT_SIZE);
-	if (ret < 0 && ret != -EIO && ret != -ENODEV) {
-		/* output_report not available, try raw_request instead */
+	/*
+	 * Only -ENOSYS means the transport has no ->output_report; fall back to
+	 * raw_request (SET_REPORT) then. Every other value is a real transport
+	 * failure - do NOT re-send it as a control transfer (that masked
+	 * -EPIPE/-ETIMEDOUT and could put the packet on the wire twice).
+	 */
+	if (ret == -ENOSYS) {
 		ret = hid_hw_raw_request(hdev, HIDPP_DD_FF_REPORT_ID,
 					 ff_work->report_buf, HIDPP_DD_FF_REPORT_SIZE,
 					 HID_OUTPUT_REPORT, HID_REQ_SET_REPORT);
@@ -7103,8 +7138,17 @@ static void hidpp_dd_ff_query_common_settings(struct hidpp_dd_ff_data *ff)
 	}
 
 	if (ff->idx_damping != HIDPP_DD_FEATURE_NOT_FOUND) {
+		/*
+		 * Damping is GET on fn0, not fn1. Unlike range/strength/brake
+		 * (fn1 = GET, fn2 = SET), the damping feature uses fn0 = GET and
+		 * fn1 = SET, and an empty-payload fn1 is "set damping = 0". This
+		 * code used to read via fn1, which ZEROED the wheel's damping on
+		 * every probe and every profile/mode switch and then cached 0.
+		 * Verified live: fn0 reads the current value; the old fn1 read
+		 * emitted a damping-changed-to-0 event.
+		 */
 		ret = hidpp_send_fap_command_sync(hidpp, ff->idx_damping,
-						  HIDPP_DD_HIDPP_FN_GET, params, 0, &response);
+						  HIDPP_DD_HIDPP_FN_GET_INFO, params, 0, &response);
 		if (ret == 0) {
 			value = (response.fap.params[0] << 8) | response.fap.params[1];
 			ff->damping = value;
@@ -7114,8 +7158,15 @@ static void hidpp_dd_ff_query_common_settings(struct hidpp_dd_ff_data *ff)
 	}
 
 	if (ff->idx_trueforce != HIDPP_DD_FEATURE_NOT_FOUND) {
+		/*
+		 * TrueForce current value is GET on fn2 (HIDPP_DD_HIDPP_FN_SET's
+		 * 0x20 numbering, not a set here). fn0 returns a constant max
+		 * (0xffff) and fn1 is the change-event slot that answers a
+		 * solicited read with 0, so the old fn1 read cached a bogus 0%.
+		 * Verified live and against G HUB's read function.
+		 */
 		ret = hidpp_send_fap_command_sync(hidpp, ff->idx_trueforce,
-						  HIDPP_DD_HIDPP_FN_GET, params, 0, &response);
+						  HIDPP_DD_HIDPP_FN_SET, params, 0, &response);
 		if (ret == 0) {
 			value = (response.fap.params[0] << 8) | response.fap.params[1];
 			ff->trueforce = value;
@@ -7644,10 +7695,28 @@ static u8 hidpp_dd_compat_lookup(struct hidpp_device *hidpp, u16 feature_id,
 	int ret;
 
 	ret = hidpp_root_get_feature(hidpp, feature_id, &idx);
-	if (ret == 0 && idx != 0)
-		return idx;
-	dd_dbg(hid,
-		"compat: ROOT.GetFeature(0x%04x) for %s returned %d, falling back to index 0x%02x\n",
+	if (ret == 0) {
+		/*
+		 * The wheel answered ROOT.GetFeature. A non-zero index means the
+		 * feature is present there; index 0 is HID++ for "feature not
+		 * present", so do NOT fall back to a hardcoded guess in that
+		 * case - a wrong guess once set the FFB filter while trying to
+		 * set something else. Report it absent; the caller returns
+		 * -EOPNOTSUPP rather than poking a bystander feature.
+		 */
+		if (idx != 0)
+			return idx;
+		dd_dbg(hid, "compat: wheel reports %s (0x%04x) not present\n",
+		       what, feature_id);
+		return HIDPP_DD_FEATURE_NOT_FOUND;
+	}
+	/*
+	 * Transport error, not a "not present" answer: old compat firmware may
+	 * not answer ROOT.GetFeature at all. Only then fall back to the
+	 * historically-verified index for this feature.
+	 */
+	dd_warn(hid,
+		"compat: ROOT.GetFeature(0x%04x) for %s failed (%d); using verified fallback index 0x%02x\n",
 		feature_id, what, ret, fallback_idx);
 	return fallback_idx;
 }
@@ -7674,6 +7743,8 @@ static int hidpp_dd_compat_set_u16(struct hidpp_device *hidpp,
 	if (*cached_idx == HIDPP_DD_FEATURE_NOT_FOUND)
 		*cached_idx = hidpp_dd_compat_lookup(hidpp, feature_id,
 						 fallback_idx, what);
+	if (*cached_idx == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;	/* wheel says the feature isn't there */
 
 	params[0] = (value >> 8) & 0xFF;
 	params[1] = value & 0xFF;
@@ -7699,6 +7770,8 @@ static int hidpp_dd_compat_set_filter(struct hidpp_device *hidpp,
 		ff->idx_compat_filter = hidpp_dd_compat_lookup(hidpp,
 			HIDPP_DD_COMPAT_FEATURE_ID_FILTER,
 			HIDPP_DD_COMPAT_FALLBACK_IDX_FILTER, "compat set filter");
+	if (ff->idx_compat_filter == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;	/* wheel says the filter feature isn't there */
 	params[0] = 0x00;
 	params[1] = 0x00;
 	params[2] = level;

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -36,6 +36,7 @@
 #include <asm/unaligned.h>
 #endif
 #include <linux/math.h>
+#include <linux/math64.h>
 
 /*
  * Kernel compatibility macros
@@ -4498,14 +4499,13 @@ struct hidpp_dd_ff_data {
 	u8 fn_set_trueforce;
 	u8 fn_set_brakeforce;
 	u8 fn_set_filter;
-	u8 fn_set_sensitivity;
 	u8 fn_set_brightness;		/* feature 0x8040 SET fn; default HIDPP_DD_HIDPP_FN_SET */
 
 	/* Mode and profile state (Feature 0x8137) */
 	u8 current_mode;		/* 0=desktop, 1=onboard */
 	u8 current_profile;		/* 0=desktop, 1-5=onboard profiles */
 	bool mode_known;		/* true once hidpp_dd_get_current_mode succeeded at least once; false means current_mode/current_profile are the safe-desktop default not a fresh query */
-	u8 sensitivity;			/* Desktop-only sensitivity (0-100), uses idx_brightness */
+	u8 sensitivity;			/* Last sensitivity written via sysfs (0-100, 50=linear); uploaded as a 0x80A4 steering curve, not readable back from the wheel */
 
 	/* Wheel settings (sysfs configurable) */
 	u16 range;			/* rotation range in degrees */
@@ -4695,6 +4695,12 @@ static int hidpp_dd_set_range_hw(struct hidpp_dd_ff_data *ff, int range);
 static void hidpp_dd_ff_effect_timer_callback(struct timer_list *t);
 static void hidpp_dd_process_pedals(struct hidpp_device *hidpp, u8 *data, int size);
 static struct hidpp_dd_ff_data *hidpp_dd_find_ff_data(struct hid_device *hdev);
+static int hidpp_dd_response_curve_upload(struct hidpp_device *hidpp,
+					  struct hidpp_dd_ff_data *ff,
+					  u8 dev_idx, u8 axis, u8 idx,
+					  const char *buf, size_t count);
+static int hidpp_dd_response_curve_revert(struct hidpp_device *hidpp,
+					  u8 dev_idx, u8 axis, u8 idx);
 
 /*
  * Project a FF_CONSTANT effect's signed level onto the wheel's X axis.
@@ -6677,8 +6683,11 @@ static int hidpp_dd_ff_raw_hidpp_event(struct hidpp_device *hidpp, u8 *data,
 	 * brightnessChangeEvent with a BE16 brightness, fired on
 	 * user-initiated changes (the wheel's OLED menu) and after a
 	 * rounded setBrightness; event 1 is illuminationChangeEvent.
-	 * Without this handler the led_brightness / sensitivity caches
-	 * went stale whenever brightness was changed on the wheel itself.
+	 * Without this handler the led_brightness cache went stale
+	 * whenever brightness was changed on the wheel itself. This is
+	 * LED brightness only: the old model that 0x8040 doubled as
+	 * desktop sensitivity was disproved on hardware (writes only dim
+	 * the LEDs; G Hub's Sensitivity slider is a 0x80A4 curve upload).
 	 * Same sw_id==0 unsolicited-broadcast gate as the handlers above.
 	 */
 	if (ff->idx_brightness != HIDPP_DD_FEATURE_NOT_FOUND &&
@@ -6691,8 +6700,6 @@ static int hidpp_dd_ff_raw_hidpp_event(struct hidpp_device *hidpp, u8 *data,
 			u8 val = min_t(u16, raw, 100);
 
 			WRITE_ONCE(ff->led_brightness, val);
-			if (ff->mode_known && ff->current_mode == 0)
-				WRITE_ONCE(ff->sensitivity, val);
 			dd_info(hidpp->hid_dev,
 				 "Brightness change broadcast -> %u%%\n",
 				 val);
@@ -7119,7 +7126,7 @@ static int hidpp_dd_lightsync_apply_slot(struct hidpp_device *hidpp,
 /*
  * Query the device for its current values of the common settings
  * (range, strength, damping, trueforce, brakeforce, ffb_filter,
- * brightness/sensitivity) and populate the ff cache. Each feature is
+ * brightness) and populate the ff cache. Each feature is
  * independent; a missing or failing query leaves the pre-populated
  * default alone. Shared by the RS50 and G Pro settings init paths so
  * they cannot drift on which settings get queried (SYS.F15).
@@ -7217,17 +7224,14 @@ static void hidpp_dd_ff_query_common_settings(struct hidpp_dd_ff_data *ff)
 	}
 
 	/*
-	 * Feature 0x8040 doubles as LED brightness (both modes) and
-	 * wheel sensitivity (desktop mode only). We cache the read value
-	 * as brightness unconditionally and as sensitivity only when
-	 * mode_known confirms desktop, so a failed mode query does not
-	 * alias a brightness value onto the sensitivity cache (SYS.F35).
-	 *
-	 * Officially this feature is x8040 BrightnessControl; the
-	 * sensitivity meaning is wheel-firmware behaviour layered on top
-	 * (the official feature has no sensitivity function). Values are
-	 * 16-bit big-endian per the official spec - decode both bytes,
-	 * not just the LSB.
+	 * Feature 0x8040 is x8040 BrightnessControl: LED brightness only.
+	 * The driver used to treat it as desktop-mode sensitivity too;
+	 * that was disproved on hardware (writes only dim the LEDs) and
+	 * against the 2026-01-30 desktop_sensitivity capture, where G
+	 * Hub's Sensitivity slider is a 0x80A4 response-curve upload on
+	 * the steering axis, so the read here must never touch
+	 * ff->sensitivity. Values are 16-bit big-endian per the official
+	 * spec - decode both bytes, not just the LSB.
 	 */
 	if (ff->idx_brightness != HIDPP_DD_FEATURE_NOT_FOUND) {
 		/*
@@ -7267,11 +7271,6 @@ static void hidpp_dd_ff_query_common_settings(struct hidpp_dd_ff_data *ff)
 
 			ff->led_brightness = val;
 			hid_dbg(hid, "Wheel: LED brightness = %d%%\n", val);
-
-			if (ff->mode_known && ff->current_mode == 0) {
-				ff->sensitivity = val;
-				hid_dbg(hid, "Wheel: sensitivity = %d%%\n", val);
-			}
 		}
 	}
 }
@@ -8425,7 +8424,27 @@ static ssize_t wheel_brake_force_store(struct device *dev, struct device_attribu
 static DEVICE_ATTR(wheel_brake_force, 0664,
 		   wheel_brake_force_show, wheel_brake_force_store);
 
-/* Sensitivity - wheel responsiveness (Desktop mode only) */
+/*
+ * Sensitivity - steering responsiveness (Desktop mode only).
+ *
+ * This is NOT feature 0x8040: hardware testing showed 0x8040 is plain
+ * BrightnessControl (writes only dim the LEDs, steering is unchanged).
+ * G Hub's Sensitivity slider is a 0x80A4 AxisResponseCurve upload on
+ * steering axis 0, protocol-mapped from the 2026-01-30
+ * desktop_sensitivity capture: for slider value v (0-100, s = v/100)
+ * G Hub samples the cubic Bezier
+ *
+ *   B(t) = 3t(1-t)^2*P1 + 3t^2(1-t)*P2 + t^3*(1,1),
+ *   P1 = (1-s, s), P2 = (s, 1-s)
+ *
+ * at 64 uniform t and uploads the (x,y) pairs scaled to 0-65535. The
+ * captured slider positions 100/75/25/0 all match this model to within
+ * 1 LSB; 50 gives the identity (G Hub sends fn6 revert-to-built-in
+ * instead of uploading it). >50 sharpens the centre, <50 softens it,
+ * symmetric about (32768, 32768). We reuse wheel_response_curve's
+ * upload core, so this attribute is just a friendly 0-100 front-end
+ * for the same hardware store.
+ */
 static ssize_t wheel_sensitivity_show(struct device *dev, struct device_attribute *attr,
 				     char *buf)
 {
@@ -8442,10 +8461,10 @@ static ssize_t wheel_sensitivity_show(struct device *dev, struct device_attribut
 		return -ENODEV;
 
 	/*
-	 * Sensitivity is only live in desktop mode; in onboard mode the
-	 * device uses a stored per-profile curve. Return the last-known
-	 * desktop value anyway so numeric parsers don't break. Users who
-	 * need to know the current mode can read wheel_mode.
+	 * The wheel has no readback for the slider value (the curve
+	 * store only reports a point count), so this is a write-through
+	 * cache: the last value stored here, defaulting to 50 (linear).
+	 * Users who need to know the current mode can read wheel_mode.
 	 */
 	return sysfs_emit(buf, "%u\n", ff->sensitivity);
 }
@@ -8456,9 +8475,10 @@ static ssize_t wheel_sensitivity_store(struct device *dev, struct device_attribu
 	struct hid_device *hid = to_hid_device(dev);
 	struct hidpp_device *hidpp = hid_get_drvdata(hid);
 	struct hidpp_dd_ff_data *ff;
-	struct hidpp_report response;
-	u8 params[3];
-	int sensitivity, ret;
+	u32 px, py, prev_in = 0;
+	int sensitivity, i, ret;
+	size_t len = 0;
+	char *curve;
 
 	if (!hidpp)
 		return -ENODEV;
@@ -8478,32 +8498,80 @@ static ssize_t wheel_sensitivity_store(struct device *dev, struct device_attribu
 	if (ret)
 		return ret;
 
-	if (ff->idx_brightness == HIDPP_DD_FEATURE_NOT_FOUND)
+	if (ff->idx_response_curve == HIDPP_DD_FEATURE_NOT_FOUND)
 		return -EOPNOTSUPP;
 
 	sensitivity = clamp(sensitivity, 0, 100);
 
-	/* Sensitivity uses the same feature as brightness (0x8040) */
-	params[0] = 0;
-	params[1] = sensitivity;
-	params[2] = 0;
+	/*
+	 * 50 = linear = the wheel's built-in curve. Mimic G Hub, which
+	 * sends fn6 revert here instead of uploading an identity curve
+	 * (equivalent steering-wise, but leaves the store reporting
+	 * "0 = built-in" rather than 64 loaded points).
+	 */
+	if (sensitivity == 50) {
+		ret = hidpp_dd_response_curve_revert(hidpp, 0xff, 0,
+						     ff->idx_response_curve);
+		ret = hidpp_errno(hid, ret, "set sensitivity");
+		if (ret)
+			return ret;
+		ff->sensitivity = 50;
+		dd_info(hid, "Sensitivity set to 50%% (linear, built-in curve)\n");
+		return count;
+	}
 
-	ret = hidpp_send_fap_command_sync(hidpp, ff->idx_brightness,
-					  ff->fn_set_sensitivity, params, 3, &response);
-	ret = hidpp_errno(hid, ret, "set sensitivity");
+	/* 64 "in:out" tokens of at most 12 chars ("65535:65535 ") + NUL */
+	curve = kmalloc(64 * 12 + 1, GFP_KERNEL);
+	if (!curve)
+		return -ENOMEM;
+
+	/*
+	 * Sample G Hub's sensitivity Bezier (see the block comment above
+	 * wheel_sensitivity_show) at the wheel's 64 native points and
+	 * render it as the "in:out" pair list the shared 0x80A4 uploader
+	 * parses. Control coordinates scaled to 0-65535:
+	 * P1 = (px, py), P2 = (py, px). Integer math throughout; the
+	 * +125023 / 250047 pair is round-to-nearest by 63^3 (t = i/63).
+	 * Verified against the capture: reproduces G Hub's uploaded
+	 * points for sliders 100/75/25/0 to within 1 LSB.
+	 */
+	px = (u32)(100 - sensitivity) * 65535 / 100;
+	py = (u32)sensitivity * 65535 / 100;
+	for (i = 0; i < 64; i++) {
+		/* Bernstein weights for t = i/63, scaled by 63^3 */
+		u64 w1 = 3ULL * i * (63 - i) * (63 - i);
+		u64 w2 = 3ULL * i * i * (63 - i);
+		u64 w3 = (u64)i * i * i;
+		u32 in = div_u64(w1 * px + w2 * py + w3 * 65535 + 125023,
+				 250047);
+		u32 out = div_u64(w1 * py + w2 * px + w3 * 65535 + 125023,
+				  250047);
+
+		/*
+		 * x(t) is flat around t=0.5 at the slider extremes, so
+		 * two samples can round to the same input value (G Hub
+		 * itself uploads such duplicates at slider 0). The
+		 * uploader demands strictly increasing inputs; dropping
+		 * the duplicate is safe since its resampler linearly
+		 * interpolates across the gap.
+		 */
+		if (i > 0 && in <= prev_in)
+			continue;
+		prev_in = in;
+		len += scnprintf(curve + len, 64 * 12 + 1 - len, "%u:%u ",
+				 in, out);
+	}
+
+	ret = hidpp_dd_response_curve_upload(hidpp, ff, 0xff, 0,
+					     ff->idx_response_curve,
+					     curve, len);
+	kfree(curve);
 	if (ret)
 		return ret;
 
-	/*
-	 * sensitivity and led_brightness map to the same HID++ feature
-	 * (0x8040) and the same wire byte in desktop mode. A write to
-	 * sensitivity necessarily overwrites whatever the wheel was using
-	 * for led_brightness; keep both caches in sync so a subsequent
-	 * wheel_led_brightness read doesn't lie about the device state.
-	 */
 	ff->sensitivity = sensitivity;
-	ff->led_brightness = sensitivity;
-	dd_info(hid, "Sensitivity set to %d%% (aliases LED brightness)\n", sensitivity);
+	dd_info(hid, "Sensitivity set to %d%% (0x80A4 steering curve)\n",
+		sensitivity);
 	return count;
 }
 
@@ -10059,16 +10127,12 @@ static ssize_t wheel_led_brightness_store(struct device *dev, struct device_attr
 	if (ret)
 		return ret;
 
-	ff->led_brightness = brightness;
 	/*
-	 * In desktop mode, the same wire byte drives wheel_sensitivity;
-	 * keep the caches aligned so a subsequent sensitivity read
-	 * doesn't report a stale value. In onboard mode sensitivity is
-	 * live-controlled by the stored per-profile curve, so we leave
-	 * it alone.
+	 * Brightness only: 0x8040 was once believed to double as desktop
+	 * sensitivity, but hardware testing disproved that (sensitivity
+	 * is a 0x80A4 curve upload), so ff->sensitivity is not touched.
 	 */
-	if (ff->current_mode == 0)
-		ff->sensitivity = brightness;
+	ff->led_brightness = brightness;
 	dd_info(hid, "LED brightness set to %d%%\n", brightness);
 	return count;
 }
@@ -11873,7 +11937,7 @@ static int hidpp_dd_ff_init(struct hidpp_device *hidpp)
 
 	/*
 	 * Default SET function numbers (verified from archived G Hub captures on RS50):
-	 *   range / strength / brakeforce / filter / sensitivity /
+	 *   range / strength / brakeforce / filter /
 	 *   brightness   -> fn=2 (0x20)    (e.g. rotation_sweep shows
 	 *                                  10ff182d for feature 0x18 RANGE)
 	 *   damping      -> fn=1 (0x10)    damping_sweep shows 10ff141d...
@@ -11887,8 +11951,14 @@ static int hidpp_dd_ff_init(struct hidpp_device *hidpp)
 	ff->fn_set_trueforce = 0x30;
 	ff->fn_set_brakeforce = HIDPP_DD_HIDPP_FN_SET;
 	ff->fn_set_filter = HIDPP_DD_HIDPP_FN_SET;
-	ff->fn_set_sensitivity = HIDPP_DD_HIDPP_FN_SET;
 	ff->fn_set_brightness = HIDPP_DD_HIDPP_FN_SET;
+
+	/*
+	 * Sensitivity has no readback (the 0x80A4 curve store only
+	 * reports a point count); seed the write-through cache with the
+	 * neutral slider midpoint (50 = linear).
+	 */
+	ff->sensitivity = 50;
 
 	/*
 	 * Initialize effect timer early so timer_delete_sync() in destroy

--- a/tools/linux_game_capture.sh
+++ b/tools/linux_game_capture.sh
@@ -22,7 +22,13 @@
 #   sudo ./dev/tools/linux_game_capture.sh [label] [duration_seconds]
 #
 #   label    : short tag, e.g. "ace_launch" or "txr_no_ffb" (default: session)
-#   duration : how long to capture (default: 60). 0 means wait for Ctrl-C.
+#   duration : one of
+#                N         capture the next N seconds, then auto-stop (default 60)
+#                0         capture until Ctrl-C, keeping everything
+#                ring[:N]  capture until Ctrl-C, keeping only the last ~N
+#                          seconds (default 60). Use this for an intermittent
+#                          bug: start it, keep playing until the problem
+#                          happens, then Ctrl-C - the last ~N s is saved.
 #
 # Typical session for the "wheel resets to 90 degrees on game launch"
 # investigation:
@@ -37,6 +43,24 @@ set -euo pipefail
 
 LABEL="${1:-session}"
 DURATION="${2:-60}"
+
+# Capture mode. `ring[:N]` records continuously into a small rolling buffer
+# and keeps only the most recent ~N seconds; everything else is handled by
+# the plain-duration path below.
+RING=0
+RING_WINDOW=60
+case "$DURATION" in
+	ring|last)     RING=1 ;;
+	ring:*|last:*) RING=1; RING_WINDOW="${DURATION#*:}" ;;
+esac
+if [ "$RING" = 1 ] && ! { [ "$RING_WINDOW" -ge 10 ] 2>/dev/null; }; then
+	echo "error: ring window must be an integer >= 10 (e.g. ring:90)" >&2
+	exit 1
+fi
+if [ "$RING" = 0 ] && ! { [ "$DURATION" -ge 0 ] 2>/dev/null; }; then
+	echo "error: duration must be a non-negative integer, 0, or ring[:N]" >&2
+	exit 1
+fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # dev/captures is the scratch convention this repo uses for all
@@ -155,7 +179,7 @@ cat <<EOF
  Wheel detected: $WHEEL_LINE
  Bus $WHEEL_BUS device $WHEEL_DEV
  Capture target : $PCAP
- Duration       : ${DURATION}s ($([ "$DURATION" = 0 ] && echo "wait for Ctrl-C" || echo "auto-stops"))
+ Duration       : $(if [ "$RING" = 1 ]; then echo "ring buffer, keeps last ~${RING_WINDOW}s (Ctrl-C to stop)"; elif [ "$DURATION" = 0 ]; then echo "until Ctrl-C (keeps everything)"; else echo "${DURATION}s (auto-stops)"; fi)
  Bundle output  : $CAPTURE_DIR/${STEM}.zip
 ----------------------------------------------------------------
 
@@ -167,11 +191,9 @@ read -r -p "Press Enter when you are READY to start capturing... " _
 # post-filter on the wheel's USB IDs in the bundle phase if we want a
 # smaller artefact, but we record everything first so a missed event on
 # a control endpoint does not invalidate the session.
-if [ "$DURATION" = 0 ]; then
-	DUR_ARG=""
-else
-	DUR_ARG="-a duration:$DURATION"
-fi
+# Ctrl-C should STOP the capture and still bundle what we have, not abort
+# the script. The trap lets bash resume after tshark exits on SIGINT.
+trap ':' INT
 
 echo
 echo "====== START START START - launch the game NOW ======"
@@ -186,11 +208,26 @@ echo
 # at 60 s is small (low-100s of kB even with FFB streaming) so the
 # extra packets are not a problem.
 set +e
-tshark -i "usbmon${WHEEL_BUS}" \
-	-w "$PCAP" \
-	$DUR_ARG \
-	-q 2>&1 | tail -2
+if [ "$RING" = 1 ]; then
+	# Rolling capture: 3 files of ~RING_WINDOW/2 s each, so at least the
+	# last RING_WINDOW seconds survive at any moment. tshark discards the
+	# oldest file as it cycles, so a multi-minute session stays tiny.
+	RING_DUR=$(( RING_WINDOW / 2 )); [ "$RING_DUR" -lt 5 ] && RING_DUR=5
+	echo "(ring buffer active: press Ctrl-C right after the problem happens)"
+	tshark -i "usbmon${WHEEL_BUS}" -w "$TMPDIR/${STEM}_ring.pcap" \
+		-b duration:"$RING_DUR" -b files:3 -q 2>&1 | tail -2
+	# Stitch the surviving ring segments into the single bundle pcap.
+	if command -v mergecap >/dev/null 2>&1; then
+		mergecap -w "$PCAP" "$TMPDIR/${STEM}_ring"*.pcap 2>/dev/null
+	else
+		cp "$(ls -t "$TMPDIR/${STEM}_ring"*.pcap | head -1)" "$PCAP"
+	fi
+else
+	[ "$DURATION" = 0 ] && DUR_ARG="" || DUR_ARG="-a duration:$DURATION"
+	tshark -i "usbmon${WHEEL_BUS}" -w "$PCAP" $DUR_ARG -q 2>&1 | tail -2
+fi
 set -e
+trap - INT
 
 echo
 echo "!!!!!!! ENDING ENDING ENDING - capture stopped !!!!!!!!"


### PR DESCRIPTION
## Summary

A batch of correctness fixes for the direct-drive wheels, driven by a review of the G HUB USB captures and a "band-aid audit" (places where a symptom had been masked instead of fixed). All driver changes are hardware-validated on an RS50 base (native/PC mode, kernel 7.1.3).

## Fixes

- **Pedal init hang (#30):** the pedal MCU (device index 0x02) silently drops HID++ software-id 0x01; it accepts 0x0a (what G HUB uses). Switching the kernel software-id to 0x0a cuts init from ~15-20 s (retry-storm) to ~0.4 s.
- **Damping read zeroed the value:** the settings re-read used the wrong function index (fn1, which *sets* damping to 0) instead of fn0 (get). Any settings refresh silently cleared the user's damping. Now uses fn0.
- **TrueForce current-value read:** used fn1 (an event slot) instead of fn2 (get current). Corrected.
- **`wheel_sensitivity`** now uploads the 0x80A4 axis-response Bezier curve (the real desktop sensitivity control) instead of aliasing 0x8040 LED brightness. Sensitivity and brightness are now fully independent.
- **Removed the `05 07` "FFB keepalive":** it was a DualShock-4 lightbar packet, not a wheel command. FFB does not depend on it (verified: FFB still works after a long idle gap).
- **RS50 rev-lights:** un-gated visibility and corrected the cadence to ~100 Hz; the buffers are now DMA-safe (the stale stack buffers triggered a USB DMA WARN and -EIO).
- **OLED-edit broadcasts:** handle the 0x8137 sw-id-0 broadcast so an on-wheel profile edit re-reads settings.
- **Transport/error-handling hardening:** output_report fallback only on -ENOSYS (real transport errors are no longer silently re-sent as control transfers); compat-lookup misses return -EOPNOTSUPP instead of a bogus index; dropped FFB samples are counted rather than silently evaporating; retry-on-timeout breaks on non-BUSY.
- **Capture tooling (#31):** ring-buffer mode keeps the last N seconds so reporters can capture an intermittent issue.
- **Docs:** protocol-spec corrections (05-07 is a DS4 packet, sensitivity = 0x80A4, damping = fn0, pedal sw-id = 0x0a).

## Hardware validation

Feel/behaviour tested on the wheel from the seat (self-guided harness):

- TrueForce texture clean, no start/stop jolt; KF route coarser (as expected).
- Constant force holds steady when a rumble is layered on (strength-scaling safety).
- Emulated autocenter centring spring pulls to centre.
- Rev-lights track the level and clear; LED brightness stays independent of sensitivity.
- FFB is just as strong after a 15 s idle gap (keepalive removal confirmed harmless).
- Damping (#9) verified objectively: set 100, force a settings re-read, value stays 100 (the old fn1 bug would zero it).

Force delivery was also traced at the transport layer (kretprobe on `hid_hw_output_report`): every send returns full success, no drops.

## Notes

- Not included: the TrueForce stream rework (1 kHz + unified sequence), deferred as higher-risk.
- Builds clean (0 warnings) against 7.1.3 with clang.
