### PR TITLE
hidpp: don't apply RS50 compat fallback indices on a real G PRO

### DIFF
--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -7741,7 +7741,25 @@ static u8 hidpp_dd_compat_lookup(struct hidpp_device *hidpp, u16 feature_id,
 	 * Transport error, not a "not present" answer: old compat firmware may
 	 * not answer ROOT.GetFeature at all. Only then fall back to the
 	 * historically-verified index for this feature.
+	 *
+	 * BUT these fallback indices are the RS50's catalog, and PID c272/c268
+	 * is shared by two very different wheels: an RS50 spoofing the G PRO
+	 * PID in compatibility mode (RS50 catalog - the fallbacks are correct)
+	 * and a REAL G PRO, whose catalog is shifted down by 2 (verified from
+	 * the issue #8 G HUB captures: e.g. idx 0x18 is the FFB FILTER on a
+	 * real G PRO, not rotation range). Applying an RS50 fallback index on a
+	 * real G PRO would cross-wire a setting into a bystander feature - the
+	 * same class of bug the ROOT.GetFeature guard above already prevents. A
+	 * real G PRO only reaches this path if native resolution also failed,
+	 * so there is no reliable index to use: report the feature absent
+	 * rather than guess.
 	 */
+	if (dd_is_real_gpro(hid)) {
+		dd_warn(hid,
+			"compat: ROOT.GetFeature(0x%04x) for %s failed (%d) on a real G PRO; RS50 fallback idx 0x%02x is wrong here, reporting absent\n",
+			feature_id, what, ret, fallback_idx);
+		return HIDPP_DD_FEATURE_NOT_FOUND;
+	}
 	dd_warn(hid,
 		"compat: ROOT.GetFeature(0x%04x) for %s failed (%d); using verified fallback index 0x%02x\n",
 		feature_id, what, ret, fallback_idx);


### PR DESCRIPTION
## Summary

Prevents `hidpp_dd_compat_lookup()` from applying RS50 fallback feature indices on a real G PRO, where they are wrong and would cross-wire settings into a bystander feature.

## Background

Analysis of the G PRO (`046d:c272`) G HUB captures from #8 showed the real G PRO speaks the same HID++ config protocol as the RS50, but with every feature index **shifted down by 2** (rotation range at `0x16` vs RS50 `0x18`, damping `0x12` vs `0x14`, TrueForce `0x17` vs `0x19`, etc.), with byte-identical functions and encodings.

The native path already handles this: it resolves every index dynamically via `ROOT.GetFeature`, so it lands on the shifted index automatically. **Native G PRO support needs no change.**

## The bug

`hidpp_dd_compat_lookup()` has a last-resort fallback to hardcoded indices when `ROOT.GetFeature` fails at the transport level. Those indices are the RS50's. Because PID `c272`/`c268` is shared by a real G PRO **and** an RS50 spoofing that PID in compatibility mode, a transport-level failure on a real G PRO would apply an RS50 index that points at the wrong feature there (index `0x18` is the FFB filter on a real G PRO, not rotation range). That is the same cross-wiring the `ROOT.GetFeature` index-0 guard just above already prevents for the "feature absent" case.

## Fix

Gate the fallback behind the existing `dd_is_real_gpro()` helper: on a real G PRO, report the feature absent (caller returns `-EOPNOTSUPP`) rather than guess. RS50-in-compat behaviour is unchanged, and the native path is untouched.

Latent, low-severity (a real G PRO only reaches this path if native resolution *also* fails), but a correctness hole worth closing now that the G PRO catalog is known.

## Test

Builds clean (0 warnings) against 7.1.3. No functional change on the RS50 (native or compat); the changed branch only triggers on a real G PRO after a transport-level `ROOT.GetFeature` failure.
