### PR TITLE
docs: release prep for v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ changes to the sysfs surface, minor versions add supported wheels or
 new attributes, patch versions are bug fixes and documentation. Pre-1.0
 the contract is "it works on RS50 and G Pro as listed here".
 
+## 0.13.0 - 2026-07-11
+
+A correctness batch from a review of the G Hub USB captures and an audit of
+places where a symptom had been masked instead of fixed, plus validation of the
+real G PRO wheel against contributor captures. All driver changes are
+hardware-verified on an RS50 (native mode, kernel 7.1.3).
+
+### Fixed
+- **Pedal init hang (#30).** The pedal MCU (device index 0x02) silently drops
+  HID++ messages sent with software-id 0x01; it accepts 0x0a (what G Hub uses).
+  Init drops from ~15-20 s of retry timeouts to ~0.4 s.
+- **Damping was zeroed on any settings re-read.** The read used function index
+  fn1 (which *sets* damping to 0) instead of fn0 (get). Now fn0.
+- **TrueForce current-value read** used fn1 (an event slot) instead of fn2.
+- **`wheel_sensitivity`** now uploads the 0x80A4 axis-response Bezier curve (the
+  real desktop sensitivity control) instead of aliasing 0x8040 LED brightness.
+  Sensitivity and brightness are fully independent.
+- **Removed the `05 07` "FFB keepalive"**, which was a DualShock-4 lightbar
+  packet, not a wheel command. FFB does not depend on it.
+- **RS50 rev-lights** un-gated, with corrected ~100 Hz cadence and DMA-safe
+  buffers (the previous stack buffers triggered a USB DMA warning).
+- **On-wheel OLED profile edits** now trigger a settings re-read (0x8137 sw0).
+- **Transport / error-handling hardening**: output_report falls back to
+  SET_REPORT only on -ENOSYS; compat-lookup misses return -EOPNOTSUPP; dropped
+  FFB samples are counted rather than silently lost; retry-on-timeout breaks on
+  non-BUSY.
+- **G PRO compat fallback (#33).** On a real G PRO, a transport-level feature
+  lookup failure no longer applies RS50 fallback indices (which are shifted on a
+  real G PRO and would cross-wire a setting into a bystander feature); it reports
+  the feature absent and logs it.
+
+### G PRO validation
+- The real G PRO (`046d:c272`) HID++ configuration protocol is confirmed against
+  contributor G Hub captures (#8): identical to the RS50 except a uniform
+  feature-index shift, which the driver resolves dynamically. The FFB / TrueForce
+  stream itself is not yet verified on a real G PRO (those captures were
+  config-only).
+
+### Packaging
+- New distribution channels: **Debian/Ubuntu (.deb)**, **Fedora COPR (akmod)**,
+  and **openSUSE OBS (DKMS)**, auto-published on each GitHub Release.
+
+### Tooling
+- `linux_game_capture.sh` gains a ring-buffer mode (`ring[:N]`) that keeps only
+  the last N seconds, for capturing intermittent issues (#31).
+
+### Documentation
+- Protocol spec corrected (05-07 is a DS4 packet; sensitivity is 0x80A4; damping
+  is fn0; pedal software-id is 0x0a), and the `wheel_sensitivity` sysfs reference
+  rewritten to match.
+
 ## 0.12.1 - 2026-07-09
 
 Packaging and documentation. No driver code change from v0.12.0 (the module

--- a/README.md
+++ b/README.md
@@ -127,8 +127,13 @@ owner to validate · - not applicable.
 The RS50 is the development hardware, so its column is verified directly
 in both native (`046d:c276`) and G PRO compatibility (`046d:c272`) modes,
 including SDK game TrueForce under Proton in each. A real G PRO runs the
-**same `hidpp_dd_ff_*` code path** as an RS50 in G PRO compatibility mode,
-so it is expected to work; we just do not have one to confirm against.
+**same `hidpp_dd_ff_*` code path** as an RS50 in G PRO compatibility mode.
+Its HID++ configuration protocol is now confirmed against real G PRO G Hub
+captures ([issue #8](https://github.com/mescon/logitech-trueforce-linux-driver/issues/8)):
+every wheel-config feature matches, differing only by a feature-index shift
+the driver resolves at runtime. Those captures did not include the
+force-feedback / TrueForce stream itself, so G PRO FFB and TrueForce are
+expected to work but not yet verified end to end.
 **G920 / G923** are handled by the
 in-tree `hid-logitech-hidpp` driver (this scoped fork no longer claims
 them); their standard HID++ FFB is unaffected, and the RS50/G-PRO-specific

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -132,7 +132,7 @@ git clone https://github.com/mescon/logitech-trueforce-linux-driver.git
 cd logitech-trueforce-linux-driver
 
 # Build the source tarball the spec expects, straight from this checkout:
-VER=0.12.1
+VER=0.13.0
 mkdir -p ~/rpmbuild/SOURCES
 git archive --prefix=logitech-trueforce-linux-driver-$VER/ \
     -o ~/rpmbuild/SOURCES/logitech-trueforce-kmod-$VER.tar.gz HEAD

--- a/docs/SYSFS_API.md
+++ b/docs/SYSFS_API.md
@@ -5,7 +5,7 @@
 - Logitech RS50 Direct Drive Wheel Base (USB `046d:c276`)
 - Logitech G Pro Racing Wheel (USB `046d:c272` Xbox/PC, `046d:c268` PS/PC)
 
-**Version**: v0.12.1 (2026-07-09)
+**Version**: v0.13.0 (2026-07-11)
 
 Most of the attributes documented here are shared between the RS50 and G Pro (the two wheels share the settings code path). Attributes that are currently G Pro-only or RS50-only are called out inline.
 
@@ -230,21 +230,26 @@ echo 75 > wheel_brake_force
 **Values**: `0` to `100` (percentage)
 **Mode Restriction**: Writes only accepted in **desktop mode**; reads always succeed.
 
-Sets the wheel sensitivity/responsiveness (Feature 0x8040, the same wire
-feature that carries LED brightness in onboard mode; the driver tracks
-them as separate caches and gates the sensitivity cache update on a
-confirmed desktop-mode query to avoid aliasing a brightness value into
-sensitivity).
+Shapes the steering response curve via feature `0x80A4`
+(AxisResponseCurve): a 64-point cubic Bezier from (0,0) to (1,1) with
+control points P1=(1-s, s), P2=(s, 1-s) for s = value/100. Values below
+`50` soften the response near centre; values above `50` sharpen it. `50`
+is the identity curve, so the driver reverts to the wheel's built-in
+curve (as G Hub does) rather than uploading a flat line.
 
-Reads return the last-known desktop sensitivity (initialised to 0 until
-the wheel has been observed in desktop mode at least once). The value
-has no effect while the wheel is in onboard mode; read `wheel_mode` to
-know which is current. Writes in onboard mode fail with `-EPERM`.
+This is unrelated to LED brightness. Feature `0x8040` (behind
+`wheel_led_brightness`) is brightness only; sensitivity and brightness are
+fully independent.
+
+Reads return the last value written, defaulting to `50`. The wheel has no
+read-back for the slider, so this is a write-through cache. Writes in
+onboard mode fail with `-EPERM`; if the wheel does not expose the
+response-curve feature, writes return `-EOPNOTSUPP`.
 
 ```bash
-# Set sensitivity to 50% (must be in desktop mode)
+# Sharpen the centre response (must be in desktop mode)
 echo "desktop" > wheel_mode
-echo 50 > wheel_sensitivity
+echo 65 > wheel_sensitivity
 ```
 
 ### wheel_ffb_filter


### PR DESCRIPTION
Doc corrections + CHANGELOG for the v0.13.0 release. Rewrites the stale wheel_sensitivity reference (0x80A4 curve, not 0x8040 brightness), records the G PRO config-protocol validation from #8, bumps version stamps, and adds the 0.13.0 changelog entry. No code change.