### PR TITLE
ci: fix the release publish workflow (Debian build-essential, container git safe.directory)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            dpkg-dev debhelper dkms dh-dkms
+            build-essential dpkg-dev debhelper dkms dh-dkms
       - name: Stamp version from the tag
         run: |
           set -eu
@@ -101,7 +101,7 @@ jobs:
         run: |
           set -eu
           VERSION="${TAG#v}"
-          git config --global --add safe.directory "$PWD"
+          git config --global --add safe.directory '*'
           # Stamp the version so the SRPM (and the akmod COPR rebuilds from it)
           # carries the release version.
           sed -i "s/^%global\\( *\\)upstream_ver.*/%global\\1upstream_ver    ${VERSION}/" \
@@ -132,7 +132,7 @@ jobs:
         run: |
           set -eu
           VERSION="${TAG#v}"
-          git config --global --add safe.directory "$PWD"
+          git config --global --add safe.directory '*'
           sed -i "s/^%global\\( *\\)modver.*/%global\\1modver   ${VERSION}/" \
             packaging/obs/logitech-trueforce-dkms.spec
           sed -i "s/^Version:.*/Version:        ${VERSION}/" \


### PR DESCRIPTION
First live run of publish-release.yml on v0.13.0 failed all three package jobs on environment issues. Debian: install build-essential (dpkg's implicit build requirement). COPR + OBS: git archive hit the container dubious-ownership guard; switch to safe.directory '*'. Fixes live in the workflow, so re-publishing v0.13.0 picks them up.