### PR TITLE
logi-dd: rename onboard profile slots (and correct the 9-char name limit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ the contract is "it works on RS50 and G Pro as listed here".
   skip the HID++ demux.
 
 ### Added
-- **Profile rename.** `wheel_profile_names` is writable (0664): `echo
-  "3:My Profile" > wheel_profile_names` renames an onboard slot via feature
-  `0x8137` fn4. The wheel persists the name to its own NVM on the single write;
-  there is no separate save step. Slots 1-5, 1-14 characters.
+- **Profile rename.** `wheel_profile_names` is writable (0664): `echo "3:RACE" >
+  wheel_profile_names` renames an onboard slot via feature `0x8137` fn4. The
+  wheel persists the name to its own NVM on the single write; there is no
+  separate save step. Slots are 1-5. An RS50 takes names of up to 9 characters
+  (matching its own stock `PROFILE 3`), stores them uppercased, and accepts
+  spaces; it refuses a longer name at the HID++ layer, reported as `-EIO`.
 
 ### Removed
 - **Pedal shaping attributes** - `wheel_{throttle,brake,clutch}_curve`,

--- a/docs/SYSFS_API.md
+++ b/docs/SYSFS_API.md
@@ -74,11 +74,10 @@ echo 0 > wheel_profile
 ## Force Feedback Settings
 
 ### wheel_profile_names
-**Access**: Read-only
+**Access**: Read/Write
 
-The five onboard slots' user-assigned names (set via G Hub or the
-wheel's OLED menu), queried live from the wheel. Use this to know
-which slot number `wheel_profile` should get.
+The five onboard slots' names, queried live from the wheel. Use this to
+know which slot number `wheel_profile` should get.
 
 ```bash
 cat wheel_profile_names
@@ -88,6 +87,21 @@ cat wheel_profile_names
 # 4: PROFILE 4
 # 5: PROFILE 5
 ```
+
+Writing renames one slot, as `<slot>:<name>` (feature `0x8137` fn4). The
+wheel persists the name to its own NVM on the write; there is no separate
+save step.
+
+```bash
+# Rename slot 3
+echo "3:RACE" > wheel_profile_names
+```
+
+Slot is 1-5. On an RS50 the name may be up to **9 characters** (the same
+length as its stock `PROFILE 3`), may contain spaces, and is stored
+**uppercased** - `echo "3:Race"` reads back as `3: RACE`. A longer name is
+refused by the wheel itself and surfaces as `-EIO`; a bad slot, an empty
+name, or one over the 14-byte HID++ payload gives `-EINVAL`.
 
 ### wheel_range
 **Access**: Read/Write

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -11125,10 +11125,18 @@ static ssize_t wheel_profile_names_show(struct device *dev,
  * persists the name to its own NVM on this one write.
  *
  * Write syntax mirrors the show format's "N: name" line:
- *   echo "3:My Profile" > wheel_profile_names
+ *   echo "3:RACE" > wheel_profile_names
  * slot is 1-5; the name is the rest of the line (a leading space after the
- * colon and one trailing newline are stripped), 1-14 bytes so [slot][len][name]
- * fits a single long HID++ report.
+ * colon and one trailing newline are stripped). The length check below is the
+ * transport limit: 1-14 bytes, so [slot][len][name] fits one long HID++ report.
+ *
+ * The wheel is stricter than the transport. An RS50 accepts at most 9
+ * characters (its own stock names are "PROFILE 3"/"PROFILE 4") and fails a
+ * longer name at the HID++ layer, which surfaces here as -EIO rather than
+ * -EINVAL; it also stores names uppercased, and accepts spaces. We keep the
+ * check at the transport limit rather than hard-coding 9, because that bound is
+ * observed on the RS50 and other wheels in this family may differ - the device
+ * remains the authority, and its refusal is reported.
  */
 static ssize_t wheel_profile_names_store(struct device *dev,
 					 struct device_attribute *attr,

--- a/userspace/logi-dd/crates/logi-dd-core/src/kind.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/kind.rs
@@ -11,6 +11,10 @@ pub enum Kind {
     RgbStrip { leds: usize },
     Curve,
     Action,
+    /// An attribute that reads back as a `N: name` list but is written one
+    /// slot at a time as `N:name` (the onboard profile names). Reads yield
+    /// `Value::SlotNames`, writes take `Value::SlotName`.
+    SlotText { slots: u8, max_len: usize },
 }
 
 impl Kind {
@@ -72,6 +76,24 @@ impl Kind {
                 Ok(Value::Curve(pts))
             }
             Kind::Action => Ok(Value::Trigger),
+            Kind::SlotText { slots, .. } => {
+                // Reads back one "N: name" line per slot. Unlisted slots stay
+                // empty rather than failing the whole read.
+                let mut names = vec![String::new(); *slots as usize];
+                for line in raw.lines() {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let (n, rest) = line.split_once(':').ok_or(Error::Parse(line.into()))?;
+                    let idx: usize =
+                        n.trim().parse().map_err(|_| Error::Parse(line.into()))?;
+                    if idx >= 1 && idx <= *slots as usize {
+                        names[idx - 1] = rest.trim().to_string();
+                    }
+                }
+                Ok(Value::SlotNames(names))
+            }
         }
     }
 
@@ -95,11 +117,30 @@ impl Kind {
                 }
             }
             (Kind::Action, Value::Trigger) => "1".into(),
+            // Writes rename a single slot; the whole list is not writable.
+            (Kind::SlotText { .. }, Value::SlotName { slot, name }) => format!("{slot}:{name}"),
             _ => return Err(Error::Invalid),
         })
     }
 
     pub fn validate(&self, v: &Value) -> Result<(), Error> {
+        // SlotText reads and writes different shapes, so the parse(format(v))
+        // round-trip below does not apply: check the write form directly.
+        if let Kind::SlotText { slots, max_len } = self {
+            return match v {
+                Value::SlotName { slot, name } => {
+                    let len = name.chars().count();
+                    if *slot >= 1 && *slot <= *slots && len >= 1 && len <= *max_len
+                        && !name.contains('\n')
+                    {
+                        Ok(())
+                    } else {
+                        Err(Error::Invalid)
+                    }
+                }
+                _ => Err(Error::Invalid),
+            };
+        }
         // parse(format(v)) proves the value satisfies this kind's constraints.
         let s = self.format(v)?;
         match self {
@@ -125,6 +166,13 @@ impl Kind {
             (Kind::Curve, Value::Curve(p)) if p.is_empty() => "built-in".into(),
             (Kind::Curve, Value::Curve(p)) => format!("{} points", p.len()),
             (Kind::Action, _) => "[trigger]".into(),
+            (Kind::SlotText { .. }, Value::SlotNames(names)) => names
+                .iter()
+                .enumerate()
+                .map(|(i, n)| format!("{}: {}", i + 1, n))
+                .collect::<Vec<_>>()
+                .join("  "),
+            (Kind::SlotText { .. }, Value::SlotName { slot, name }) => format!("{slot}: {name}"),
             _ => "?".into(),
         }
     }
@@ -198,5 +246,74 @@ mod tests {
         let k = Kind::TextField { max_len: 8 };
         assert!(k.parse("RACE").is_ok());
         assert!(matches!(k.parse("waytoolongname"), Err(Error::Invalid)));
+    }
+}
+
+#[cfg(test)]
+mod slot_text_tests {
+    use super::*;
+
+    const K: Kind = Kind::SlotText { slots: 5, max_len: 9 };
+
+    #[test]
+    fn parses_the_drivers_list_read() {
+        let v = K.parse("1: QZX7\n2: GT7\n3: PROFILE 3\n4: PROFILE 4\n5: TEST").unwrap();
+        assert_eq!(
+            v,
+            Value::SlotNames(vec![
+                "QZX7".into(),
+                "GT7".into(),
+                "PROFILE 3".into(),
+                "PROFILE 4".into(),
+                "TEST".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn missing_slots_read_back_empty() {
+        let v = K.parse("2: GT7").unwrap();
+        let Value::SlotNames(names) = v else { panic!("wrong variant") };
+        assert_eq!(names.len(), 5);
+        assert_eq!(names[1], "GT7");
+        assert_eq!(names[0], "");
+    }
+
+    #[test]
+    fn writes_one_slot_as_n_colon_name() {
+        let w = Value::SlotName { slot: 3, name: "My Profile".into() };
+        assert_eq!(K.format(&w).unwrap(), "3:My Profile");
+    }
+
+    #[test]
+    fn the_whole_list_is_not_writable() {
+        // Reads yield SlotNames; writing it back would send the list to a
+        // store that takes a single "N:name".
+        assert!(K.format(&Value::SlotNames(vec!["a".into()])).is_err());
+        assert!(K.validate(&Value::SlotNames(vec!["a".into()])).is_err());
+    }
+
+    #[test]
+    fn validate_enforces_the_drivers_limits() {
+        let ok = |s: u8, n: &str| K.validate(&Value::SlotName { slot: s, name: n.into() });
+        assert!(ok(1, "A").is_ok());
+        assert!(ok(5, "PROFILE 3").is_ok()); // 9 = the wheel's own stock name
+        assert!(ok(0, "A").is_err(), "slot 0 is below the 1-5 range");
+        assert!(ok(6, "A").is_err(), "slot 6 is above the 1-5 range");
+        assert!(ok(1, "").is_err(), "empty name is rejected by the driver");
+        // The wheel rejects >9 with -EIO (verified on an RS50); 14 is only the
+        // HID++ payload cap, so cap at what the hardware actually takes.
+        assert!(ok(1, "ABCDEFGHIJ").is_err(), "10 chars is refused by the wheel");
+        assert!(ok(1, "two\nlines").is_err());
+    }
+
+    #[test]
+    fn name_may_contain_spaces_and_colons() {
+        // The driver splits on the FIRST colon only, so both survive.
+        assert!(K.validate(&Value::SlotName { slot: 2, name: "GT7: race".into() }).is_ok());
+        assert_eq!(
+            K.format(&Value::SlotName { slot: 2, name: "GT7: race".into() }).unwrap(),
+            "2:GT7: race"
+        );
     }
 }

--- a/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
@@ -45,7 +45,10 @@ pub const REGISTRY: &[SettingSpec] = &[
     // --- Profiles / mode ---
     SettingSpec { attr: "wheel_mode", label: "Mode", help: "desktop (host-controlled) or onboard (wheel-stored).", category: Profiles, kind: Kind::Enum(&["desktop", "onboard"]), access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_profile", label: "Profile", help: "Active profile (0=desktop, 1-5 onboard).", category: Profiles, kind: Kind::IntRange { min: 0, max: 5, step: 1, unit: "" }, access: ReadWrite, mode_req: Any },
-    SettingSpec { attr: "wheel_profile_names", label: "Profile names", help: "The 5 onboard slot names.", category: Profiles, kind: Kind::TextField { max_len: 256 }, access: ReadOnly, mode_req: Any },
+    // max_len is the wheel's limit (9), not the driver's protocol cap (14):
+    // the RS50 rejects a longer name with -EIO. The wheel stores names
+    // uppercased.
+    SettingSpec { attr: "wheel_profile_names", label: "Profile names", help: "Rename an onboard slot: left/right picks the slot, type a name (1-9 chars, stored uppercase).", category: Profiles, kind: Kind::SlotText { slots: 5, max_len: 9 }, access: ReadWrite, mode_req: Any },
     // --- Calibration ---
     SettingSpec { attr: "wheel_calibrate_here", label: "Calibrate centre here", help: "Adopt the current physical position as centre.", category: Calibration, kind: Kind::Action, access: Action, mode_req: Any },
     // --- Info ---
@@ -66,6 +69,9 @@ pub(crate) fn sample_raw(s: &SettingSpec) -> String {
         Kind::RgbStrip { leds } => vec!["000000"; leds].join(" "),
         Kind::Curve => "reset".into(),
         Kind::Action => "1".into(),
+        Kind::SlotText { slots, .. } => {
+            (1..=slots).map(|i| format!("{i}: NAME{i}")).collect::<Vec<_>>().join("\n")
+        }
     }
 }
 
@@ -88,6 +94,14 @@ mod tests {
         // drawn from its own current default, proving the registry is coherent.
         for s in REGISTRY {
             if matches!(s.access, Access::Action) {
+                continue;
+            }
+            // SlotText reads back the whole list but writes a single slot, so
+            // parse->format is deliberately not a round-trip; its own tests
+            // cover both directions.
+            if matches!(s.kind, crate::Kind::SlotText { .. }) {
+                let raw = super::sample_raw(s);
+                s.kind.parse(&raw).unwrap_or_else(|e| panic!("{}: {e}", s.attr));
                 continue;
             }
             // pick a trivially valid raw for this kind and round-trip it

--- a/userspace/logi-dd/crates/logi-dd-core/src/value.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/value.rs
@@ -33,6 +33,11 @@ pub enum Value {
     Rgb(Vec<Color>),
     Curve(Vec<(u16, u16)>),
     Trigger,
+    /// Every slot name, as read back (index 0 = slot 1).
+    SlotNames(Vec<String>),
+    /// Rename one slot. The attribute reads back as the whole list but writes
+    /// one slot at a time, so reads yield `SlotNames` and writes take this.
+    SlotName { slot: u8, name: String },
 }
 
 #[cfg(test)]

--- a/userspace/logi-dd/crates/logi-dd-tui/src/app.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/app.rs
@@ -121,12 +121,10 @@ impl<S: SysfsIo> App<S> {
     /// does not expose them.
     pub fn profile_names(&self) -> BTreeMap<u8, String> {
         let mut m = BTreeMap::new();
-        if let Ok(Value::Text(s)) = self.device.read("wheel_profile_names") {
-            for line in s.lines() {
-                if let Some((num, name)) = line.split_once(':') {
-                    if let Ok(n) = num.trim().parse::<u8>() {
-                        m.insert(n, name.trim().to_string());
-                    }
+        if let Ok(Value::SlotNames(names)) = self.device.read("wheel_profile_names") {
+            for (i, name) in names.iter().enumerate() {
+                if !name.is_empty() {
+                    m.insert(i as u8 + 1, name.clone());
                 }
             }
         }

--- a/userspace/logi-dd/crates/logi-dd-tui/src/edit.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/edit.rs
@@ -5,6 +5,10 @@ pub struct EditState {
     pub kind: Kind,
     pub draft: Value,
     pub buffer: String,
+    /// Which slot the edit targets (1-based). Only meaningful for
+    /// `Kind::SlotText`, where bumping picks the slot and the buffer holds
+    /// that slot's new name.
+    pub slot: u8,
 }
 
 impl EditState {
@@ -17,16 +21,30 @@ impl EditState {
                 _ => String::new(),
             },
             Kind::RgbStrip { .. } | Kind::Curve => kind.format(current).unwrap_or_default(),
+            // Seed with slot 1's existing name so a rename starts from what is
+            // on the wheel rather than a blank field.
+            Kind::SlotText { .. } => slot_name(current, 1),
             _ => String::new(),
         };
-        EditState { attr, kind, draft: current.clone(), buffer }
+        EditState { attr, kind, draft: current.clone(), buffer, slot: 1 }
     }
 
     fn is_text_mode(&self) -> bool {
-        matches!(self.kind, Kind::TextField { .. } | Kind::RgbStrip { .. } | Kind::Curve)
+        matches!(
+            self.kind,
+            Kind::TextField { .. } | Kind::RgbStrip { .. } | Kind::Curve | Kind::SlotText { .. }
+        )
     }
 
     pub fn bump(&mut self, d: i32) {
+        // SlotText: bumping moves between slots, reloading each slot's current
+        // name into the buffer, rather than changing the draft value.
+        if let Kind::SlotText { slots, .. } = self.kind {
+            let n = slots as i32;
+            self.slot = ((self.slot as i32 - 1 + d).rem_euclid(n) + 1) as u8;
+            self.buffer = slot_name(&self.draft, self.slot);
+            return;
+        }
         self.draft = match (self.kind, &self.draft) {
             (Kind::Percent, Value::Percent(n)) => {
                 Value::Percent((*n as i32 + d).clamp(0, 100) as u8)
@@ -45,7 +63,7 @@ impl EditState {
 
     pub fn push_char(&mut self, c: char) {
         match self.kind {
-            Kind::TextField { max_len } => {
+            Kind::TextField { max_len } | Kind::SlotText { max_len, .. } => {
                 if self.buffer.chars().count() < max_len {
                     self.buffer.push(c);
                 }
@@ -62,6 +80,13 @@ impl EditState {
     }
 
     pub fn commit_value(&self) -> Result<Value, Error> {
+        // SlotText writes one slot; the buffer is that slot's new name, so it
+        // is not parsed as a value (parse reads the whole-list form).
+        if let Kind::SlotText { .. } = self.kind {
+            let v = Value::SlotName { slot: self.slot, name: self.buffer.clone() };
+            self.kind.validate(&v)?;
+            return Ok(v);
+        }
         if self.is_text_mode() {
             // Parse the raw buffer (validates encoding/length).
             self.kind.parse(&self.buffer)
@@ -73,11 +98,24 @@ impl EditState {
 
     /// What to show for the row currently being edited.
     pub fn display(&self) -> String {
+        if let Kind::SlotText { .. } = self.kind {
+            return format!("{}: {}_", self.slot, self.buffer);
+        }
         if self.is_text_mode() {
             format!("{}_", self.buffer)
         } else {
             self.kind.display(&self.draft)
         }
+    }
+}
+
+/// The current name of `slot` (1-based) from a `SlotNames` value, or empty.
+fn slot_name(v: &Value, slot: u8) -> String {
+    match v {
+        Value::SlotNames(names) => {
+            names.get(slot.saturating_sub(1) as usize).cloned().unwrap_or_default()
+        }
+        _ => String::new(),
     }
 }
 
@@ -143,5 +181,96 @@ mod tests {
             e.push_char(c);
         }
         assert_eq!(e.commit_value().unwrap(), Value::Curve(vec![(0, 0), (65535, 65535)]));
+    }
+}
+
+#[cfg(test)]
+mod slot_text_tests {
+    use super::*;
+    use logi_dd_core::{Kind, Value};
+
+    const K: Kind = Kind::SlotText { slots: 5, max_len: 9 };
+
+    fn current() -> Value {
+        Value::SlotNames(vec![
+            "QZX7".into(),
+            "GT7".into(),
+            "PROFILE 3".into(),
+            "PROFILE 4".into(),
+            "TEST".into(),
+        ])
+    }
+
+    #[test]
+    fn starts_on_slot_1_seeded_with_its_current_name() {
+        let e = EditState::start("wheel_profile_names", K, &current());
+        assert_eq!(e.slot, 1);
+        assert_eq!(e.buffer, "QZX7");
+    }
+
+    #[test]
+    fn bump_picks_the_slot_and_reloads_its_name() {
+        let mut e = EditState::start("wheel_profile_names", K, &current());
+        e.bump(1);
+        assert_eq!((e.slot, e.buffer.as_str()), (2, "GT7"));
+        e.bump(1);
+        assert_eq!((e.slot, e.buffer.as_str()), (3, "PROFILE 3"));
+        e.bump(-1);
+        assert_eq!((e.slot, e.buffer.as_str()), (2, "GT7"));
+    }
+
+    #[test]
+    fn slot_wraps_around_both_ends() {
+        let mut e = EditState::start("wheel_profile_names", K, &current());
+        e.bump(-1);
+        assert_eq!(e.slot, 5, "below slot 1 wraps to the last slot");
+        e.bump(1);
+        assert_eq!(e.slot, 1);
+    }
+
+    #[test]
+    fn typing_a_name_and_committing_writes_that_slot() {
+        let mut e = EditState::start("wheel_profile_names", K, &current());
+        e.bump(2); // slot 3
+        for _ in 0..("PROFILE 3".len()) {
+            e.backspace();
+        }
+        for c in "Race".chars() {
+            e.push_char(c);
+        }
+        let v = e.commit_value().unwrap();
+        assert_eq!(v, Value::SlotName { slot: 3, name: "Race".into() });
+        // and that value encodes to what the driver's store expects
+        assert_eq!(K.format(&v).unwrap(), "3:Race");
+    }
+
+    #[test]
+    fn name_is_capped_at_the_drivers_limit() {
+        let mut e = EditState::start("wheel_profile_names", K, &current());
+        for _ in 0..4 {
+            e.backspace();
+        }
+        for c in "ABCDEFGHIJKLMNOPQRST".chars() {
+            e.push_char(c);
+        }
+        assert_eq!(e.buffer.chars().count(), 9, "buffer stops at the wheel's 9-char limit");
+        assert!(e.commit_value().is_ok());
+    }
+
+    #[test]
+    fn an_emptied_name_is_rejected_rather_than_written() {
+        let mut e = EditState::start("wheel_profile_names", K, &current());
+        for _ in 0..4 {
+            e.backspace();
+        }
+        assert!(e.buffer.is_empty());
+        assert!(e.commit_value().is_err(), "the driver rejects a zero-length name");
+    }
+
+    #[test]
+    fn display_shows_the_slot_being_renamed() {
+        let mut e = EditState::start("wheel_profile_names", K, &current());
+        e.bump(1);
+        assert_eq!(e.display(), "2: GT7_");
     }
 }

--- a/userspace/logi-dd/crates/logi-dd-tui/src/ui.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/ui.rs
@@ -95,15 +95,6 @@ pub fn draw<S: SysfsIo>(f: &mut Frame, app: &App<S>) {
                     _ => -1,
                 };
                 (profile_label(n, &names), value_style(editing.is_some(), false))
-            } else if row.attr == "wheel_profile_names" {
-                match &row.value {
-                    Ok(Value::Text(s)) => (
-                        s.lines().collect::<Vec<_>>().join("    "),
-                        Style::default().fg(Color::Gray),
-                    ),
-                    Err(e) => (format!("<{e}>"), Style::default().fg(Color::Red)),
-                    _ => ("?".to_string(), Style::default()),
-                }
             } else {
                 match (&row.value, spec) {
                     (Ok(v), Some(s)) => {


### PR DESCRIPTION
The driver gained profile rename, but the settings app could only *display* the slot names - `wheel_profile_names` was still listed read-only. This wires the rename into logi-dd, and corrects the documented name limit, which was wrong.

## The limit is 9 characters, not 14

`1-14` was the *transport* bound (`[slot][len][name]` in one long HID++ report). The wheel is stricter. Verified on an RS50:

```
  len 9:  OK       'ABCDEFGHI'
  len 10: REJECTED 'ABCDEFGHIJ'
```

The tell was in plain sight: the wheel's own stock names are `PROFILE 3` / `PROFILE 4` - exactly 9. A longer name is refused by the wheel at the HID++ layer, so it surfaces as `-EIO`, not `-EINVAL`. Two other undocumented behaviours: names are stored **uppercased** (`Race` reads back as `RACE`), and **spaces are accepted** (`AB CD` works).

The driver's check stays at the transport limit rather than hard-coding 9: that bound is observed on the RS50 and other wheels in this family may differ, so the device remains the authority and its refusal is reported. The docs now describe the real behaviour, and the sysfs reference documents the rename (it still called the attribute read-only).

## Wiring it into logi-dd

The attribute is **asymmetric**: it reads back as a `N: name` list but writes one slot at a time as `N:name`. Simply flipping it to a writable `TextField` would seed the editor with the whole multi-line list and then send that list to a store that takes a single pair.

So it is modelled honestly - `Kind::SlotText { slots, max_len }`, with `Value::SlotNames` for what you read and `Value::SlotName { slot, name }` for what you write:

- the editor starts on slot 1 seeded with its current name; left/right picks the slot and reloads that slot's name
- typing edits the name, capped at the wheel's 9 characters, so the editor cannot compose something the wheel will refuse
- committing writes only that slot

`max_len` is the hardware limit, so logi-dd's validation now agrees with the wheel exactly (9 accepted, 10 refused - confirmed against the live device). The registry coherence test skips the `parse -> format` round-trip for this kind, since the two directions differ by design and are covered by their own tests.

Also drops a `ui.rs` special-case that rendered the names via `Value::Text` and ignored the edit state - it would have hidden the editor; the generic path already handles both.

## Verification

- 54 tests pass (35 core + 19 TUI), clippy clean, driver builds clean
- 13 new tests cover the read format, the single-slot write encoding, the wheel's limits, slot picking/wrapping, the length cap, and that an emptied name is refused rather than written
- End-to-end on an RS50: the exact string the encoder produces is accepted by the driver, and the 9/10-character boundary logi-dd enforces matches the wheel