### PR TITLE
docs: correct inject_pid's relationship to PROTON_ENABLE_HIDRAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,12 +624,21 @@ under [Verified game support](#verified-game-support); TrueForce in
 SDK-aware sims needs the Proton recipe above. Some games want Steam Input
 enabled as a gamepad, or `SDL_JOYSTICK_DEVICE=/dev/input/eventX`.
 
-**Experimental `inject_pid` module parameter:** for non-SDK games that use
-standard DirectInput PID force feedback (older/indie sims), the driver can
-inject a PID output collection on interface 0 and translate DInput FFB
-into evdev. Off by default (`inject_pid=0`); `=1` dry-runs (logs only,
-no actuation), `=2` actuates (bench-tested only). Unrelated to
-`PROTON_ENABLE_HIDRAW`, and not needed for any SDK-aware sim.
+**Experimental `inject_pid` module parameter:** the wheel's own report
+descriptor carries no PID (force-feedback) collection on any of its three
+interfaces. That costs nothing while Wine is on its SDL/evdev backend, which
+reaches force feedback through evdev, and nothing for SDK-aware sims, whose
+force arrives over the SDK path (which is why ACC and AC EVO keep full FFB
+with `PROTON_ENABLE_HIDRAW=1`). It matters for a sim that drives FFB through
+**DirectInput** rather than the SDK: with `PROTON_ENABLE_HIDRAW=1` Wine talks
+to the wheel over hidraw, looks for a PID collection to send effects to, finds
+none, and the game loses force feedback entirely while its inputs keep
+working. Turning this parameter on makes the driver inject a PID output
+collection on interface 0 and translate the DirectInput FFB writes back into
+evdev. Off by default (`inject_pid=0`); `=1` dry-runs (logs only, no
+actuation), `=2` actuates. Bench-tested only, so hold the wheel loosely and
+start at a low `wheel_strength`. Without it, a DirectInput-FFB sim has to run
+`PROTON_ENABLE_HIDRAW=0`, which costs TrueForce.
 
 ## Technical details
 


### PR DESCRIPTION
The README said `inject_pid` was "Unrelated to `PROTON_ENABLE_HIDRAW`". The hidraw path is in fact the *only* one where the parameter does anything, which matters because it is a candidate answer for the no-FFB-under-hidraw reports in #21 and #27.

**Verified on the RS50:** the wheel exposes no PID usage page (`05 0f`) on any of its three interfaces (141 / 84 / 30-byte descriptors).

| Mode | Wine backend | FFB route | Result |
|---|---|---|---|
| `PROTON_ENABLE_HIDRAW=0` | SDL/evdev | evdev FFB | works |
| `PROTON_ENABLE_HIDRAW=1` | hidraw | DirectInput needs a PID collection, none exists | no FFB, inputs fine |

SDK-aware sims (ACC, AC EVO) are unaffected in hidraw mode because their force arrives over the SDK path, which is why they keep full FFB there. A DirectInput-FFB sim does not, and `inject_pid` supplies exactly the missing collection.

Docs only, no code change. Also notes the low-`wheel_strength` precaution, since `=2` actuates and is bench-tested only.