### PR TITLE
Hardware pedal shaping (0x80A4): curves, sensitivity, deadzones + logi-dd editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ changes to the sysfs surface, minor versions add supported wheels or
 new attributes, patch versions are bug fixes and documentation. Pre-1.0
 the contract is "it works on RS50 and G Pro as listed here".
 
+## Unreleased
+
+### Added
+- **Hardware pedal shaping.** The pedal unit (HID++ sub-device `0x02`) applies a
+  `0x80A4` response curve to each axis it reports to the PC, the same mechanism
+  as the steering wheel. Verified on an RS50 for all three pedals with an
+  artifact-proof test (a two-plateau throttle curve, and step curves on the
+  load-cell brake and clutch, each producing a bimodal axis a linear pedal
+  cannot). Each pedal `<p>` in {throttle, brake, clutch} gains three attributes,
+  all writing the single curve the axis holds (last write wins):
+  - `wheel_<p>_curve` - raw `in:out` points or `reset`, like `wheel_response_curve`.
+  - `wheel_<p>_sensitivity` - the 0-100 G HUB slider (50 = linear).
+  - `wheel_<p>_deadzone` - `"lower upper"` percent dead travel (sum <= 99).
+
+  This corrects the v0.14.0 removal, which rested on a single untested capture;
+  the pedal MCU does apply the curve, it was a measurement error.
+- **logi-dd curve editor.** A G HUB-style modal point editor for the pedal and
+  steering curves: edit control points (input/output percent) plus deadzones
+  with a live ASCII preview, then upload. Plus registry entries for the nine new
+  pedal attributes.
+
 ## 0.14.0 - 2026-07-16
 
 An input-dropping bug fixed, onboard profiles renameable, and the pedal

--- a/README.md
+++ b/README.md
@@ -550,11 +550,19 @@ echo 1 | sudo tee $WHEEL_DEV/wheel_led_apply
 
 **Pedals:**
 
-The throttle, brake and clutch are reported exactly as the wheel sends them.
-The driver does not shape them, so there are no pedal curve, deadzone or
-combined-pedals attributes - see `docs/SYSFS_API.md`.
+The pedal unit applies a hardware response curve to each axis it reports (the
+same `0x80A4` mechanism as the steering wheel; verified on an RS50). Each pedal
+`<p>` in {`throttle`, `brake`, `clutch`} has three attributes, all writing the
+one curve the axis holds (last write wins):
 
-See `docs/SYSFS_API.md` for complete API documentation with examples.
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `wheel_<p>_curve` | `reset` or `in:out` pairs | Full response curve (like `wheel_response_curve`) |
+| `wheel_<p>_sensitivity` | 0-100 (50=linear) | G HUB sensitivity slider |
+| `wheel_<p>_deadzone` | `"lower upper"` % | Dead travel at each end (sum ≤ 99) |
+
+The `logi-dd` app has a G HUB-style point editor for these curves. See
+`docs/SYSFS_API.md` for the complete reference with examples.
 
 ### Oversteer Compatibility
 

--- a/docs/SYSFS_API.md
+++ b/docs/SYSFS_API.md
@@ -722,17 +722,62 @@ echo 1 > wheel_led_apply
 
 ## Pedal Configuration
 
-The driver reports the throttle, brake and clutch axes exactly as the wheel
-sends them; it does not shape them. There are no pedal curve, deadzone or
-combined-pedals attributes.
+The pedal unit is a separate MCU (HID++ sub-device `0x02`) that applies a
+64-point `0x80A4` response curve to each axis it reports to the PC. This was
+verified live on an RS50 (2026-07-16) with a two-plateau throttle curve: the
+reported axis dwelt at exactly the two programmed output values with an empty
+gap between them, which a linear axis cannot do. So these are real shaping
+controls, the same mechanism as the steering `wheel_response_curve`.
 
-Earlier releases exposed `wheel_{throttle,brake,clutch}_curve`,
-`wheel_{throttle,brake,clutch}_deadzone`, `wheel_combined_pedals` and
-`wheel_pedal_response_curve`. Those transforms never reached userspace - the
-rewritten report did not survive to the input layer - so the attributes
-accepted settings that did nothing. They were removed rather than left
-advertising a feature that silently no-ops. Shape pedals in userspace (for
-example with a HID-BPF program) instead.
+Each pedal `<p>` in {`throttle`, `brake`, `clutch`} exposes three attributes.
+**They all write the single curve the axis holds, so the last write wins.** The
+`_curve` attribute always reads back the wheel's true loaded-point count.
+
+### wheel_&lt;p&gt;_curve
+**Access**: Read/Write
+
+The raw 64-point curve, identical in format to `wheel_response_curve`: write
+`reset` for the built-in linear curve, or 2-64 whitespace-separated `in:out`
+pairs (0-65535, strictly increasing `in`, non-decreasing `out`, starting `0:0`
+and ending `65535:65535`; fewer than 64 pairs are resampled). Reads back
+`"<loaded>/<max> points loaded"`.
+
+```bash
+# Dead-until-30%, then linear, on the throttle
+echo "0:0 19660:0 65535:65535" > wheel_throttle_curve
+echo reset > wheel_throttle_curve
+cat wheel_throttle_curve      # e.g. "64/64 points loaded (0 = built-in curve)"
+```
+
+### wheel_&lt;p&gt;_sensitivity
+**Access**: Read/Write, **Values**: `0`-`100` (`50` = linear)
+
+G HUB's simple sensitivity slider. Values above 50 make the pedal more
+responsive early in its travel, below 50 less; `50` reverts to the built-in
+linear curve. Generates the same symmetric-Bezier curve G HUB uploads. The
+wheel stores only the resulting curve, so this reads back the last written
+slider value, not a device query.
+
+```bash
+echo 70 > wheel_brake_sensitivity
+```
+
+### wheel_&lt;p&gt;_deadzone
+**Access**: Read/Write, **Values**: `"<lower> <upper>"` percent
+
+Dead travel at each end: output holds 0 until the pedal passes `lower`%, and
+reaches full by `(100 - upper)`%. `lower + upper` must be at most 99. `"0 0"`
+reverts to the built-in curve. Reads back the last written pair.
+
+```bash
+# 8% dead at the bottom, 5% saturation at the top of the clutch
+echo "8 5" > wheel_clutch_deadzone
+```
+
+> Because sensitivity, deadzone and the raw curve all write the one hardware
+> curve per axis, use one of them at a time per pedal. To combine a deadzone
+> with a custom shape, author the whole thing as a single `_curve` upload (this
+> is what the logi-dd editor does).
 
 ---
 

--- a/docs/superpowers/specs/2026-07-16-pedal-shaping-hardware-design.md
+++ b/docs/superpowers/specs/2026-07-16-pedal-shaping-hardware-design.md
@@ -1,0 +1,210 @@
+# Hardware Pedal Shaping (0x80A4) Design
+
+**Status:** draft for review
+**Date:** 2026-07-16
+**Supersedes:** the HID-BPF pedal-shaping approach (see "Why not HID-BPF").
+
+## Goal
+
+Restore G HUB-equivalent pedal shaping (throttle / brake / clutch response
+curves, per-pedal sensitivity, per-pedal deadzones) plus a logi-dd advanced
+curve editor, using the wheel's own hardware `0x80A4` response-curve feature on
+the pedal sub-device. Bring the driver to parity with G HUB's Pedals panel.
+
+## Why this, and why not HID-BPF
+
+The v0.14.0 removal of the pedal-curve attributes, and the entire HID-BPF pedal
+shaper, both rested on one untested capture that concluded "the pedal MCU stores
+a `0x80A4` curve but does not apply it to its PC HID output."
+
+That conclusion is **false**, proven on hardware 2026-07-16. The pedal MCU
+(HID++ device index `0x02`, `0x80A4` at feature index `0x0a`) applies an
+uploaded curve to the axis it reports to the PC, in desktop mode, exactly like
+the steering axis on the base. Artifact-proof test: a DOUBLE-plateau curve
+(physical throttle 8000-25000 -> 6000, 40000-58000 -> 50000) produced two
+separate dwell spikes at exactly 6000 and 50000 with an empty middle. No
+monotonic press on a linear axis can dwell at two separated values while
+skipping the gap, so this is proof, not inference. The earlier July "no effect"
+was a false negative from noisy manual testing; the July Windows raw-HID
+"linear" capture was desktop-mode with G Hub running, where G Hub reverts the
+hardware curve and shapes in software. Throttle evdev axis = `ABS_RX`; brake and
+clutch are axes 1 and 2 on the same feature.
+
+So pedal shaping needs no BPF, no userspace HID-report rewriting, and no split
+of the FFB-forwarding path. It is the same mechanism the validated
+`wheel_response_curve` (steering) already uses, pointed at three more axes on a
+different sub-device. This design uses that mechanism.
+
+## Global Constraints
+
+- GPL-2.0, no PII, no AI/LLM mentions in code/commits/docs.
+- Keep FFB / TrueForce untouched.
+- No em-dashes or en-dashes in any output.
+- The wheel stores exactly ONE curve per axis. Sensitivity and deadzone are
+  curve *generators*, not independent hardware state. This must be honest in the
+  sysfs surface: reads reflect the true loaded curve, not a remembered slider.
+- Reuse the existing, capture-verified `0x80A4` upload machinery
+  (`hidpp_dd_response_curve_upload` / `_revert`) and the steering sensitivity
+  Bezier generator. No new protocol invented for curves or sensitivity.
+
+## Architecture
+
+Three layers, phased so each is independently shippable:
+
+- **Phase 1 (driver, sysfs):** pedal-axis `0x80A4` curves, sensitivity, and
+  deadzone attributes. Reuses existing machinery. Hardware-validated.
+- **Phase 2 (logi-dd):** registry entries + the advanced curve editor TUI.
+  Pure userspace, unit-tested with `FakeSysfs`.
+- **Phase 3 (combined pedals):** protocol IS known from the 2026-07-14 capture
+  (feature idx `0x0e` fn1 bool: `10 ff 0e 1a 01` on / `00` off, desktop-only).
+  Lower priority (off for modern sims) and needs its own hardware validation
+  that it transforms the PC HID output, so it is sequenced last but is not
+  blocked on any new capture.
+
+### Data flow (one pedal)
+
+```
+G HUB-simple:  sensitivity 0-100  ─┐
+G HUB-advanced: point list+deadzone ┼─> 64-point 0x80A4 curve ─> dev 0x02 axis a
+sysfs deadzone: "L U"              ─┘         (last write wins; the wheel
+                                               holds exactly one curve/axis)
+```
+
+The wheel's axis holds one curve. Whichever attribute wrote last defines it.
+`wheel_<p>_curve` always reads back the true loaded/max point count from the
+device (fn1), so it is the source of truth regardless of which generator wrote.
+
+## Phase 1: Driver sysfs surface
+
+For each pedal `p` in {`throttle`, `brake`, `clutch`} mapping to `0x80A4` axis
+`a` in {0, 1, 2} on device index `0x02`:
+
+### `wheel_<p>_curve` (RW) — the canonical curve
+
+Mirrors `wheel_response_curve` exactly, only `dev_idx=0x02, axis=a, idx=idx_pedal_curve`:
+
+- Write `reset` -> `hidpp_dd_response_curve_revert(hidpp, 0x02, a, idx_pedal_curve)`.
+- Write 2-64 whitespace-separated `in:out` pairs (decimal 0-65535, strictly
+  increasing `in`, non-decreasing `out`, starting `0:0`, ending `65535:65535`)
+  -> `hidpp_dd_response_curve_upload(...)`. Fewer than 64 pairs are resampled to
+  64 by the existing uploader.
+- Read -> `"<loaded>/<max> points loaded (0 = built-in curve)"` via fn1, exactly
+  like the steering show.
+- `-EOPNOTSUPP` if `idx_pedal_curve == HIDPP_DD_FEATURE_NOT_FOUND`.
+
+### `wheel_<p>_sensitivity` (RW) — the simple slider
+
+Reuses the steering Bezier generator verbatim (`wheel_sensitivity_store`'s
+symmetric cubic Bezier: P1=(px,py), P2=(py,px), px=(100-s)*65535/100,
+py=s*65535/100, sampled at 64 points), uploaded to `dev 0x02 axis a`:
+
+- Write `0-100`, clamped. `50` -> fn6 revert (built-in linear), matching G HUB.
+- Otherwise generate the 64-point curve and upload.
+- Read -> the last written value (cached in `ff`, like steering; the wheel does
+  not store the slider position, only the resulting curve).
+
+### `wheel_<p>_deadzone` (RW) — lower/upper dead travel
+
+A convenience generator for the common "linear with dead ends" shape:
+
+- Write `"<lower> <upper>"`, each `0-100` percent, `lower + upper <= 99`.
+- Composes a 4-point curve: `0:0`, `(lower%*65535):0`, `((100-upper)%*65535):65535`,
+  `65535:65535` and uploads it via the shared uploader (which resamples to 64).
+- Read -> the last written `"<lower> <upper>"` (cached in `ff`; not recoverable
+  from the stored curve).
+- `"0 0"` -> fn6 revert (built-in).
+
+### Init
+
+At probe, discover `0x80A4` on device index `0x02` via
+`hidpp_root_get_feature_on_device(hidpp, 0x02, 0x80A4, &idx)` and cache it as
+`ff->idx_pedal_curve` (default `HIDPP_DD_FEATURE_NOT_FOUND`). One extra root-get
+at init; the pedal MCU already answers HID++ during pedal init, so no new
+transport concern. Add `ff->pedal_sens[3]` and `ff->pedal_deadzone[3][2]` caches.
+
+### Attribute count
+
+9 new attributes (3 pedals x {curve, sensitivity, deadzone}). All in the
+existing `attribute_group`. `combine_pedals` / `wheel_combined_pedals` are NOT
+added here (Phase 3).
+
+## Phase 2: logi-dd
+
+### Core (`logi-dd-core`)
+
+- Registry: 9 `SettingSpec`s in a new `Pedals` category. Curve attrs use the
+  existing `Kind::Curve`. Sensitivity uses `Kind::Percent`. Deadzone needs a new
+  `Kind::Pair { max: u8 }` that parses/formats `"L U"` into a
+  `Value::Pair(u8, u8)`.
+- `mode_req`: match the driver. Curve/deadzone are `Any` (no mode gating in the
+  store); sensitivity mirrors whatever the driver enforces (steering sensitivity
+  is desktop-only via `-EPERM`; pedal sensitivity store SHOULD match, so
+  `DesktopOnly` if the driver gates it, else `Any` - to be fixed to agree with
+  the Phase 1 code).
+
+### The advanced curve editor (TUI)
+
+A modal editor entered from a pedal curve row, chosen UX = point-list + live
+ASCII preview:
+
+- **Model:** an ordered `Vec<Point { input: u16, output: u16 }>` plus
+  `lower_deadzone: u8`, `upper_deadzone: u8`. On save, compose these into a
+  `Value::Curve` (deadzones become the flat end-segments; points sit between)
+  and write via the existing `Device::write`.
+- **Left panel:** selected point index (`< n / N >`), Input%, Output%, Lower
+  deadzone%, Upper deadzone%, all editable by typing; `+`/`-` add/delete the
+  selected point; arrows move between points.
+- **Right panel:** a live ASCII plot (input on X, output on Y) redrawn on every
+  edit, with the selected point marked.
+- **Invariants enforced live:** inputs strictly increasing, outputs
+  non-decreasing, endpoints pinned to `0:0` and `100:100` (the deadzones shift
+  where the curve leaves 0 and reaches 100, they do not move the endpoints).
+  Invalid edits are rejected in the editor, so a malformed curve never reaches
+  the wheel.
+- **Preview rendering** is a pure function `(points, w, h) -> Vec<String>`,
+  unit-tested independently of the terminal.
+
+### logi-dd testing
+
+- Curve composition (points + deadzones -> `Value::Curve`) is a pure function
+  with unit tests, including deadzone-only, sensitivity-shaped, and arbitrary
+  curves.
+- `Kind::Pair` parse/format/validate round-trip tests.
+- Editor state transitions (add/delete/move/edit, invariant rejection) tested
+  against the model, not the terminal.
+- Registry coherence test extended for the new kinds.
+
+## Phase 3: Combined pedals (protocol known, sequenced last)
+
+`Kombinerade pedaler` merges gas+brake into one split axis for legacy games. It
+is a separate mechanism from `0x80A4`, and its protocol IS known from the
+2026-07-14 G HUB capture: **feature index `0x0e`, fn1, boolean** -
+`10 ff 0e 1a 01` enables, `10 ff 0e 1a 00` disables, desktop-mode-only. It is
+off for all modern sims, so it is the lowest priority. Implemented as
+`wheel_combined_pedals` (RW 0/1) discovering `0x0e` at init, with the same
+hardware validation the curves get (confirm it transforms the PC HID output, not
+just stores state). Not blocked on any new capture. Sequenced after Phases 1-2.
+
+## Testing and validation
+
+- **Phase 1 hardware validation** (when the wheel returns to the Linux host):
+  the throttle-curve application is already proven. Validate brake (axis 1) and
+  clutch (axis 2) with the same plateau-and-control method (each is a small
+  number of held presses). Validate that sensitivity and deadzone attrs produce
+  the expected curve shape via the same axis recording. The cue goes in
+  assistant text, never inside a recorded command; record in the background.
+- **Phase 2** is fully testable without hardware (`FakeSysfs` + pure-function
+  unit tests). Hardware smoke test: drive one real curve from the TUI and
+  confirm the axis shapes.
+- No regression to steering (`wheel_response_curve`), FFB, or TrueForce: the new
+  code only adds attributes and one init-time feature lookup.
+
+## Risks
+
+- **Brake/clutch might gate or behave differently from throttle.** Low: same
+  feature, same sub-device, adjacent axes. Validated before Phase 1 ships.
+- **Last-write-wins across three generators per axis may confuse users.**
+  Mitigated by `wheel_<p>_curve` always reading the true device state and by
+  documenting the model in SYSFS_API.md.
+- **Combined pedals capture may reveal a mechanism we cannot drive from Linux.**
+  Contained: Phase 3 is isolated and does not affect Phases 1-2.

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -11040,6 +11040,243 @@ static DEVICE_ATTR(wheel_response_curve, 0664, wheel_response_curve_show,
 		   wheel_response_curve_store);
 
 /*
+ * Pedal shaping: 0x80A4 response curves on the pedal sub-device (0x02), axes
+ * 0=throttle, 1=brake, 2=clutch. Hardware-verified 2026-07-16 that the pedal
+ * MCU applies an uploaded curve to its PC HID output (double-plateau test).
+ *
+ * Each pedal exposes three sysfs generators that all write the ONE curve the
+ * axis holds, so the last write wins:
+ *   wheel_<p>_curve        raw "in:out" points (or "reset"), like the steering
+ *                          wheel_response_curve; reads back the true loaded/max
+ *                          point count from the device (fn1).
+ *   wheel_<p>_sensitivity  0-100 slider (50 = linear); generates the G Hub
+ *                          Bezier curve. Cached for readback (the wheel stores
+ *                          only the resulting curve, not the slider value).
+ *   wheel_<p>_deadzone     "<lower> <upper>" percent dead travel; generates a
+ *                          curve flat at 0 below lower% and flat at full above
+ *                          (100-upper)%. Cached for readback.
+ */
+static struct hidpp_dd_ff_data *hidpp_dd_pedal_ff(struct hidpp_device *hidpp,
+						  int *err)
+{
+	struct hidpp_dd_ff_data *ff;
+
+	if (!hidpp) {
+		*err = -ENODEV;
+		return NULL;
+	}
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping)) {
+		*err = -ENODEV;
+		return NULL;
+	}
+	if (ff->idx_pedal_curve == HIDPP_DD_FEATURE_NOT_FOUND) {
+		*err = -EOPNOTSUPP;
+		return NULL;
+	}
+	*err = 0;
+	return ff;
+}
+
+static ssize_t hidpp_dd_pedal_curve_show(struct hid_device *hid, u8 axis,
+					 char *buf)
+{
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_report response;
+	struct hidpp_dd_ff_data *ff;
+	u8 params[1] = { axis };
+	u16 loaded, max;
+	int ret;
+
+	ff = hidpp_dd_pedal_ff(hidpp, &ret);
+	if (!ff)
+		return ret;
+
+	memset(&response, 0, sizeof(response));
+	ret = hidpp_send_fap_to_device_sync(hidpp, HIDPP_DD_PEDAL_DEV_IDX,
+					    ff->idx_pedal_curve,
+					    0x10 /* fn1 axis info */,
+					    params, 1, &response);
+	if (ret)
+		return hidpp_errno(hid, ret, "read pedal curve info");
+	loaded = get_unaligned_be16(&response.fap.params[6]);
+	max = get_unaligned_be16(&response.fap.params[8]);
+	return sysfs_emit(buf, "%u/%u points loaded (0 = built-in curve)\n",
+			  loaded, max);
+}
+
+static ssize_t hidpp_dd_pedal_curve_store(struct hid_device *hid, u8 axis,
+					  const char *buf, size_t count)
+{
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	int ret;
+
+	ff = hidpp_dd_pedal_ff(hidpp, &ret);
+	if (!ff)
+		return ret;
+
+	if (sysfs_streq(buf, "reset")) {
+		ret = hidpp_dd_response_curve_revert(hidpp, HIDPP_DD_PEDAL_DEV_IDX,
+						     axis, ff->idx_pedal_curve);
+		return ret ? hidpp_errno(hid, ret, "reset pedal curve") : count;
+	}
+	ret = hidpp_dd_response_curve_upload(hidpp, ff, HIDPP_DD_PEDAL_DEV_IDX,
+					     axis, ff->idx_pedal_curve, buf, count);
+	return ret < 0 ? ret : count;
+}
+
+static ssize_t hidpp_dd_pedal_sensitivity_show(struct hid_device *hid, u8 axis,
+					       char *buf)
+{
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	int ret;
+
+	ff = hidpp_dd_pedal_ff(hidpp, &ret);
+	if (!ff)
+		return ret;
+	return sysfs_emit(buf, "%u\n", ff->pedal_sens[axis]);
+}
+
+static ssize_t hidpp_dd_pedal_sensitivity_store(struct hid_device *hid, u8 axis,
+						const char *buf, size_t count)
+{
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	int sensitivity, ret;
+	size_t len;
+	char *curve;
+
+	ff = hidpp_dd_pedal_ff(hidpp, &ret);
+	if (!ff)
+		return ret;
+	ret = kstrtoint(buf, 10, &sensitivity);
+	if (ret)
+		return ret;
+	sensitivity = clamp(sensitivity, 0, 100);
+
+	if (sensitivity == 50) {
+		ret = hidpp_dd_response_curve_revert(hidpp, HIDPP_DD_PEDAL_DEV_IDX,
+						     axis, ff->idx_pedal_curve);
+		if (ret)
+			return hidpp_errno(hid, ret, "set pedal sensitivity");
+		ff->pedal_sens[axis] = 50;
+		return count;
+	}
+
+	curve = kmalloc(HIDPP_DD_SENS_CURVE_BUFSZ, GFP_KERNEL);
+	if (!curve)
+		return -ENOMEM;
+	len = hidpp_dd_build_sensitivity_curve(sensitivity, curve,
+					       HIDPP_DD_SENS_CURVE_BUFSZ);
+	ret = hidpp_dd_response_curve_upload(hidpp, ff, HIDPP_DD_PEDAL_DEV_IDX,
+					     axis, ff->idx_pedal_curve, curve, len);
+	kfree(curve);
+	if (ret)
+		return ret;
+	ff->pedal_sens[axis] = sensitivity;
+	return count;
+}
+
+static ssize_t hidpp_dd_pedal_deadzone_show(struct hid_device *hid, u8 axis,
+					    char *buf)
+{
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	int ret;
+
+	ff = hidpp_dd_pedal_ff(hidpp, &ret);
+	if (!ff)
+		return ret;
+	return sysfs_emit(buf, "%u %u\n", ff->pedal_deadzone[axis][0],
+			  ff->pedal_deadzone[axis][1]);
+}
+
+static ssize_t hidpp_dd_pedal_deadzone_store(struct hid_device *hid, u8 axis,
+					     const char *buf, size_t count)
+{
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	unsigned int lower, upper;
+	char curve[64];
+	u32 lo_in, hi_in;
+	int ret, n = 0;
+
+	ff = hidpp_dd_pedal_ff(hidpp, &ret);
+	if (!ff)
+		return ret;
+	if (sscanf(buf, "%u %u", &lower, &upper) != 2 ||
+	    lower > 100 || upper > 100 || lower + upper > 99)
+		return -EINVAL;
+
+	if (lower == 0 && upper == 0) {
+		ret = hidpp_dd_response_curve_revert(hidpp, HIDPP_DD_PEDAL_DEV_IDX,
+						     axis, ff->idx_pedal_curve);
+		if (ret)
+			return hidpp_errno(hid, ret, "reset pedal deadzone");
+		ff->pedal_deadzone[axis][0] = 0;
+		ff->pedal_deadzone[axis][1] = 0;
+		return count;
+	}
+
+	/*
+	 * Output holds 0 until input passes lower%, then rises to full by
+	 * (100-upper)%. Only the non-zero deadzone points are emitted so the
+	 * curve keeps strictly-increasing inputs and the pinned 0:0 / 65535
+	 * endpoints the uploader requires.
+	 */
+	lo_in = (u32)lower * 65535 / 100;
+	hi_in = (u32)(100 - upper) * 65535 / 100;
+	n += scnprintf(curve + n, sizeof(curve) - n, "0:0");
+	if (lower > 0)
+		n += scnprintf(curve + n, sizeof(curve) - n, " %u:0", lo_in);
+	if (upper > 0)
+		n += scnprintf(curve + n, sizeof(curve) - n, " %u:65535", hi_in);
+	n += scnprintf(curve + n, sizeof(curve) - n, " 65535:65535");
+
+	ret = hidpp_dd_response_curve_upload(hidpp, ff, HIDPP_DD_PEDAL_DEV_IDX,
+					     axis, ff->idx_pedal_curve, curve, n);
+	if (ret)
+		return ret;
+	ff->pedal_deadzone[axis][0] = lower;
+	ff->pedal_deadzone[axis][1] = upper;
+	return count;
+}
+
+/* Generate the nine per-pedal sysfs wrappers (curve/sensitivity/deadzone). */
+#define HIDPP_DD_PEDAL_ATTRS(pname, axis)				       \
+static ssize_t wheel_##pname##_curve_show(struct device *dev,		       \
+		struct device_attribute *attr, char *buf)		       \
+{ return hidpp_dd_pedal_curve_show(to_hid_device(dev), axis, buf); }	       \
+static ssize_t wheel_##pname##_curve_store(struct device *dev,		       \
+		struct device_attribute *attr, const char *buf, size_t count)  \
+{ return hidpp_dd_pedal_curve_store(to_hid_device(dev), axis, buf, count); }    \
+static DEVICE_ATTR(wheel_##pname##_curve, 0664,				       \
+		   wheel_##pname##_curve_show, wheel_##pname##_curve_store);    \
+static ssize_t wheel_##pname##_sensitivity_show(struct device *dev,	       \
+		struct device_attribute *attr, char *buf)		       \
+{ return hidpp_dd_pedal_sensitivity_show(to_hid_device(dev), axis, buf); }      \
+static ssize_t wheel_##pname##_sensitivity_store(struct device *dev,	       \
+		struct device_attribute *attr, const char *buf, size_t count)  \
+{ return hidpp_dd_pedal_sensitivity_store(to_hid_device(dev), axis, buf, count); } \
+static DEVICE_ATTR(wheel_##pname##_sensitivity, 0664,			       \
+		   wheel_##pname##_sensitivity_show,			       \
+		   wheel_##pname##_sensitivity_store);			       \
+static ssize_t wheel_##pname##_deadzone_show(struct device *dev,	       \
+		struct device_attribute *attr, char *buf)		       \
+{ return hidpp_dd_pedal_deadzone_show(to_hid_device(dev), axis, buf); }	       \
+static ssize_t wheel_##pname##_deadzone_store(struct device *dev,	       \
+		struct device_attribute *attr, const char *buf, size_t count)  \
+{ return hidpp_dd_pedal_deadzone_store(to_hid_device(dev), axis, buf, count); } \
+static DEVICE_ATTR(wheel_##pname##_deadzone, 0664,			       \
+		   wheel_##pname##_deadzone_show, wheel_##pname##_deadzone_store)
+
+HIDPP_DD_PEDAL_ATTRS(throttle, 0);
+HIDPP_DD_PEDAL_ATTRS(brake, 1);
+HIDPP_DD_PEDAL_ATTRS(clutch, 2);
+
+/*
  * wheel_serial / wheel_firmware: read-only identity from DeviceInfo
  * (feature 0x0003), read once at init. The serial is the real
  * 12-character device serial (matches the USB iSerial); firmware shows
@@ -11272,6 +11509,15 @@ static struct attribute *hidpp_dd_wheel_group_attrs[] = {
 	&dev_attr_wheel_profile_names.attr,
 	&dev_attr_wheel_range_restore.attr,
 	&dev_attr_wheel_response_curve.attr,
+	&dev_attr_wheel_throttle_curve.attr,
+	&dev_attr_wheel_throttle_sensitivity.attr,
+	&dev_attr_wheel_throttle_deadzone.attr,
+	&dev_attr_wheel_brake_curve.attr,
+	&dev_attr_wheel_brake_sensitivity.attr,
+	&dev_attr_wheel_brake_deadzone.attr,
+	&dev_attr_wheel_clutch_curve.attr,
+	&dev_attr_wheel_clutch_sensitivity.attr,
+	&dev_attr_wheel_clutch_deadzone.attr,
 	&dev_attr_wheel_compat_range.attr,
 	&dev_attr_wheel_compat_gain.attr,
 	&dev_attr_wheel_compat_autocenter.attr,

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -4234,6 +4234,7 @@ static void hidpp_ff_retry_work(struct work_struct *work)
 #define HIDPP_DD_PAGE_TRUEFORCE		0x8139	/* TRUEFORCE Bass Shaker */
 #define HIDPP_DD_PAGE_FILTER		0x8140	/* FFB Filter */
 #define HIDPP_DD_PAGE_RESPONSE_CURVE	0x80A4	/* Per-axis 64-point response curves */
+#define HIDPP_DD_PEDAL_DEV_IDX		0x02	/* HID++ sub-device index of the pedal unit (0x80A4 axis curves) */
 #define HIDPP_DD_PAGE_CALIBRATE		0x812C	/* Centre calibration (G Pro sub-device 0x05) */
 #define HIDPP_DD_PAGE_SYNC			0x1BC0	/* Unknown sync/prepare feature */
 
@@ -4457,6 +4458,7 @@ struct hidpp_dd_ff_data {
 	u8 idx_brakeforce;		/* Feature index for brake force */
 	u8 idx_filter;			/* Feature index for FFB filter */
 	u8 idx_response_curve;		/* Feature index for 0x80A4 axis response curves (steering, base dev 0xff) */
+	u8 idx_pedal_curve;		/* Feature index for 0x80A4 curves on the pedal unit (dev 0x02, axes 0-2) */
 	u8 idx_brightness;		/* Feature index for LED brightness */
 	u8 idx_lightsync;		/* Feature index for LIGHTSYNC effects */
 	u8 idx_rgb_config;		/* Feature index for RGB Zone Config */
@@ -4505,6 +4507,14 @@ struct hidpp_dd_ff_data {
 	u8 current_profile;		/* 0=desktop, 1-5=onboard profiles */
 	bool mode_known;		/* true once hidpp_dd_get_current_mode succeeded at least once; false means current_mode/current_profile are the safe-desktop default not a fresh query */
 	u8 sensitivity;			/* Last sensitivity written via sysfs (0-100, 50=linear); uploaded as a 0x80A4 steering curve, not readable back from the wheel */
+	/*
+	 * Pedal shaping generator inputs, indexed 0=throttle 1=brake 2=clutch.
+	 * Like steering sensitivity, the wheel stores only the resulting 0x80A4
+	 * curve, not these inputs, so the last value written is cached here for
+	 * readback. pedal_sens defaults to 50 (linear); pedal_deadzone to 0/0.
+	 */
+	u8 pedal_sens[3];
+	u8 pedal_deadzone[3][2];		/* [axis][0]=lower %, [axis][1]=upper % */
 
 	/* Wheel settings (sysfs configurable) */
 	u16 range;			/* rotation range in degrees */
@@ -6750,6 +6760,8 @@ static void hidpp_dd_discover_settings_features(struct hidpp_dd_ff_data *ff)
 	ff->idx_brakeforce = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_filter = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_response_curve = HIDPP_DD_FEATURE_NOT_FOUND;
+	ff->idx_pedal_curve = HIDPP_DD_FEATURE_NOT_FOUND;
+	ff->pedal_sens[0] = ff->pedal_sens[1] = ff->pedal_sens[2] = 50;
 	ff->idx_brightness = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_profile = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_profile_notify = HIDPP_DD_FEATURE_NOT_FOUND;
@@ -6791,6 +6803,20 @@ static void hidpp_dd_discover_settings_features(struct hidpp_dd_ff_data *ff)
 	if (ret == 0)
 		dd_dbg(hid, "Response curve feature at index 0x%02x\n",
 		       ff->idx_response_curve);
+
+	/*
+	 * The pedal unit is a separate MCU (device index 0x02) that exposes the
+	 * same 0x80A4 feature at its own index, covering three axes (0=throttle,
+	 * 1=brake, 2=clutch). Hardware-verified 2026-07-16: the pedal MCU applies
+	 * an uploaded curve to its PC HID output, so these are real shaping
+	 * controls, not just onboard/console storage.
+	 */
+	ret = hidpp_root_get_feature_on_device(hidpp, HIDPP_DD_PEDAL_DEV_IDX,
+					       HIDPP_DD_PAGE_RESPONSE_CURVE,
+					       &ff->idx_pedal_curve);
+	if (ret == 0)
+		dd_dbg(hid, "Pedal response curve feature at index 0x%02x (dev 0x%02x)\n",
+		       ff->idx_pedal_curve, HIDPP_DD_PEDAL_DEV_IDX);
 
 	ret = hidpp_root_get_feature(hidpp, HIDPP_DD_PAGE_BRIGHTNESS, &ff->idx_brightness);
 	if (ret == 0)
@@ -8461,15 +8487,60 @@ static ssize_t wheel_sensitivity_show(struct device *dev, struct device_attribut
 	return sysfs_emit(buf, "%u\n", ff->sensitivity);
 }
 
+/* 64 "in:out" tokens of at most 12 chars ("65535:65535 ") + NUL. */
+#define HIDPP_DD_SENS_CURVE_BUFSZ	(64 * 12 + 1)
+
+/*
+ * Render G Hub's symmetric-Bezier sensitivity curve for slider value
+ * `sensitivity` (1-100 excluding 50) into `curve` (capacity `cap`) as the
+ * "in:out" pair list the 0x80A4 uploader parses; returns the byte length.
+ * Control coordinates scaled to 0-65535: P1 = (px, py), P2 = (py, px).
+ * Integer math throughout; the +125023 / 250047 pair is round-to-nearest by
+ * 63^3 (t = i/63). Verified against the capture: reproduces G Hub's uploaded
+ * points for sliders 100/75/25/0 to within 1 LSB. Slider 50 is the linear
+ * built-in curve and is handled by callers via fn6 revert, not here. Used for
+ * both the steering (dev 0xff) and pedal (dev 0x02) sensitivity sliders.
+ */
+static size_t hidpp_dd_build_sensitivity_curve(int sensitivity, char *curve,
+					       size_t cap)
+{
+	u32 px = (u32)(100 - sensitivity) * 65535 / 100;
+	u32 py = (u32)sensitivity * 65535 / 100;
+	u32 prev_in = 0;
+	size_t len = 0;
+	int i;
+
+	for (i = 0; i < 64; i++) {
+		/* Bernstein weights for t = i/63, scaled by 63^3 */
+		u64 w1 = 3ULL * i * (63 - i) * (63 - i);
+		u64 w2 = 3ULL * i * i * (63 - i);
+		u64 w3 = (u64)i * i * i;
+		u32 in = div_u64(w1 * px + w2 * py + w3 * 65535 + 125023, 250047);
+		u32 out = div_u64(w1 * py + w2 * px + w3 * 65535 + 125023, 250047);
+
+		/*
+		 * x(t) is flat around t=0.5 at the slider extremes, so two
+		 * samples can round to the same input value (G Hub itself
+		 * uploads such duplicates at slider 0). The uploader demands
+		 * strictly increasing inputs; dropping the duplicate is safe
+		 * since its resampler interpolates across the gap.
+		 */
+		if (i > 0 && in <= prev_in)
+			continue;
+		prev_in = in;
+		len += scnprintf(curve + len, cap - len, "%u:%u ", in, out);
+	}
+	return len;
+}
+
 static ssize_t wheel_sensitivity_store(struct device *dev, struct device_attribute *attr,
 				      const char *buf, size_t count)
 {
 	struct hid_device *hid = to_hid_device(dev);
 	struct hidpp_device *hidpp = hid_get_drvdata(hid);
 	struct hidpp_dd_ff_data *ff;
-	u32 px, py, prev_in = 0;
-	int sensitivity, i, ret;
-	size_t len = 0;
+	int sensitivity, ret;
+	size_t len;
 	char *curve;
 
 	if (!hidpp)
@@ -8512,48 +8583,12 @@ static ssize_t wheel_sensitivity_store(struct device *dev, struct device_attribu
 		return count;
 	}
 
-	/* 64 "in:out" tokens of at most 12 chars ("65535:65535 ") + NUL */
-	curve = kmalloc(64 * 12 + 1, GFP_KERNEL);
+	curve = kmalloc(HIDPP_DD_SENS_CURVE_BUFSZ, GFP_KERNEL);
 	if (!curve)
 		return -ENOMEM;
 
-	/*
-	 * Sample G Hub's sensitivity Bezier (see the block comment above
-	 * wheel_sensitivity_show) at the wheel's 64 native points and
-	 * render it as the "in:out" pair list the shared 0x80A4 uploader
-	 * parses. Control coordinates scaled to 0-65535:
-	 * P1 = (px, py), P2 = (py, px). Integer math throughout; the
-	 * +125023 / 250047 pair is round-to-nearest by 63^3 (t = i/63).
-	 * Verified against the capture: reproduces G Hub's uploaded
-	 * points for sliders 100/75/25/0 to within 1 LSB.
-	 */
-	px = (u32)(100 - sensitivity) * 65535 / 100;
-	py = (u32)sensitivity * 65535 / 100;
-	for (i = 0; i < 64; i++) {
-		/* Bernstein weights for t = i/63, scaled by 63^3 */
-		u64 w1 = 3ULL * i * (63 - i) * (63 - i);
-		u64 w2 = 3ULL * i * i * (63 - i);
-		u64 w3 = (u64)i * i * i;
-		u32 in = div_u64(w1 * px + w2 * py + w3 * 65535 + 125023,
-				 250047);
-		u32 out = div_u64(w1 * py + w2 * px + w3 * 65535 + 125023,
-				  250047);
-
-		/*
-		 * x(t) is flat around t=0.5 at the slider extremes, so
-		 * two samples can round to the same input value (G Hub
-		 * itself uploads such duplicates at slider 0). The
-		 * uploader demands strictly increasing inputs; dropping
-		 * the duplicate is safe since its resampler linearly
-		 * interpolates across the gap.
-		 */
-		if (i > 0 && in <= prev_in)
-			continue;
-		prev_in = in;
-		len += scnprintf(curve + len, 64 * 12 + 1 - len, "%u:%u ",
-				 in, out);
-	}
-
+	len = hidpp_dd_build_sensitivity_curve(sensitivity, curve,
+					       HIDPP_DD_SENS_CURVE_BUFSZ);
 	ret = hidpp_dd_response_curve_upload(hidpp, ff, 0xff, 0,
 					     ff->idx_response_curve,
 					     curve, len);

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -6761,7 +6761,14 @@ static void hidpp_dd_discover_settings_features(struct hidpp_dd_ff_data *ff)
 	ff->idx_filter = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_response_curve = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_pedal_curve = HIDPP_DD_FEATURE_NOT_FOUND;
+	/*
+	 * Re-discovery (e.g. after a replug) drops the wheel's uploaded curves
+	 * back to built-in, so the generator caches must reset to match: 50 =
+	 * linear sensitivity, no deadzone. Otherwise a stale deadzone readback
+	 * would claim shaping the axis no longer has.
+	 */
 	ff->pedal_sens[0] = ff->pedal_sens[1] = ff->pedal_sens[2] = 50;
+	memset(ff->pedal_deadzone, 0, sizeof(ff->pedal_deadzone));
 	ff->idx_brightness = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_profile = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_profile_notify = HIDPP_DD_FEATURE_NOT_FOUND;

--- a/userspace/logi-dd/crates/logi-dd-core/examples/apply.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/examples/apply.rs
@@ -1,0 +1,25 @@
+//! Dev-only harness: discover the real wheel and write one attribute through
+//! the same `Device` path the app uses. Not shipped in any binary.
+//!
+//!   cargo run --example apply -p logi-dd-core -- <attr> <value>
+//!
+//! e.g. cargo run --example apply -p logi-dd-core -- \
+//!          wheel_throttle_curve "0:0 20000:5000 45000:5000 65535:65535"
+
+use logi_dd_core::{Device, Value, REGISTRY};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let attr = args.next().expect("usage: apply <attr> <value>");
+    let raw = args.next().expect("usage: apply <attr> <value>");
+
+    let spec = REGISTRY
+        .iter()
+        .find(|s| s.attr == attr)
+        .unwrap_or_else(|| panic!("unknown attr {attr}"));
+
+    let dev = Device::discover().expect("no wheel found");
+    let v: Value = spec.kind.parse(&raw).expect("bad value for this attr");
+    dev.write(&attr, &v).expect("write failed");
+    println!("wrote {attr} = {v:?}");
+}

--- a/userspace/logi-dd/crates/logi-dd-core/src/kind.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/kind.rs
@@ -10,6 +10,9 @@ pub enum Kind {
     TextField { max_len: usize },
     RgbStrip { leds: usize },
     Curve,
+    /// Two percent values `"lower upper"` whose sum must not exceed `max`
+    /// (a pedal deadzone: dead travel at each end). Yields `Value::Pair`.
+    Pair { max: u8 },
     Action,
     /// An attribute that reads back as a `N: name` list but is written one
     /// slot at a time as `N:name` (the onboard profile names). Reads yield
@@ -75,6 +78,20 @@ impl Kind {
                 }
                 Ok(Value::Curve(pts))
             }
+            Kind::Pair { max } => {
+                let mut it = raw.split_whitespace();
+                let lower = it.next().ok_or_else(|| Error::Parse(raw.into()))?;
+                let upper = it.next().ok_or_else(|| Error::Parse(raw.into()))?;
+                if it.next().is_some() {
+                    return Err(Error::Parse(raw.into()));
+                }
+                let lower: u8 = lower.parse().map_err(|_| Error::Parse(raw.into()))?;
+                let upper: u8 = upper.parse().map_err(|_| Error::Parse(raw.into()))?;
+                if lower as u16 + upper as u16 > *max as u16 {
+                    return Err(Error::OutOfRange);
+                }
+                Ok(Value::Pair(lower, upper))
+            }
             Kind::Action => Ok(Value::Trigger),
             Kind::SlotText { slots, .. } => {
                 // Reads back one "N: name" line per slot. Unlisted slots stay
@@ -116,6 +133,7 @@ impl Kind {
                     pts.iter().map(|(a, b)| format!("{a}:{b}")).collect::<Vec<_>>().join(" ")
                 }
             }
+            (Kind::Pair { .. }, Value::Pair(lo, hi)) => format!("{lo} {hi}"),
             (Kind::Action, Value::Trigger) => "1".into(),
             // Writes rename a single slot; the whole list is not writable.
             (Kind::SlotText { .. }, Value::SlotName { slot, name }) => format!("{slot}:{name}"),
@@ -165,6 +183,8 @@ impl Kind {
             (Kind::RgbStrip { .. }, Value::Rgb(cs)) => format!("{} LEDs", cs.len()),
             (Kind::Curve, Value::Curve(p)) if p.is_empty() => "built-in".into(),
             (Kind::Curve, Value::Curve(p)) => format!("{} points", p.len()),
+            (Kind::Pair { .. }, Value::Pair(lo, hi)) if *lo == 0 && *hi == 0 => "none".into(),
+            (Kind::Pair { .. }, Value::Pair(lo, hi)) => format!("{lo}% / {hi}%"),
             (Kind::Action, _) => "[trigger]".into(),
             (Kind::SlotText { .. }, Value::SlotNames(names)) => names
                 .iter()
@@ -246,6 +266,29 @@ mod tests {
         let k = Kind::TextField { max_len: 8 };
         assert!(k.parse("RACE").is_ok());
         assert!(matches!(k.parse("waytoolongname"), Err(Error::Invalid)));
+    }
+
+    #[test]
+    fn pair_parse_format_validate() {
+        let k = Kind::Pair { max: 99 };
+        assert_eq!(k.parse("8 5").unwrap(), Value::Pair(8, 5));
+        assert_eq!(k.parse("0 0").unwrap(), Value::Pair(0, 0));
+        assert_eq!(k.format(&Value::Pair(8, 5)).unwrap(), "8 5");
+        assert!(k.validate(&Value::Pair(50, 49)).is_ok()); // sum 99 exactly
+        // sum over max is rejected
+        assert!(matches!(k.parse("60 50"), Err(Error::OutOfRange)));
+        assert!(matches!(k.validate(&Value::Pair(60, 50)), Err(Error::OutOfRange)));
+        // shape errors
+        assert!(matches!(k.parse("8"), Err(Error::Parse(_))));
+        assert!(matches!(k.parse("8 5 3"), Err(Error::Parse(_))));
+        assert!(matches!(k.parse("a b"), Err(Error::Parse(_))));
+    }
+
+    #[test]
+    fn pair_display() {
+        let k = Kind::Pair { max: 99 };
+        assert_eq!(k.display(&Value::Pair(0, 0)), "none");
+        assert_eq!(k.display(&Value::Pair(8, 5)), "8% / 5%");
     }
 }
 

--- a/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
@@ -28,9 +28,20 @@ pub const REGISTRY: &[SettingSpec] = &[
     SettingSpec { attr: "wheel_trueforce", label: "TrueForce intensity", help: "Audio-haptic texture intensity (0-100%).", category: TrueForce, kind: PCT, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_texture_route", label: "Texture routing", help: "Route rumble/texture to TrueForce (tf) or steering (kf).", category: TrueForce, kind: Kind::Enum(&["kf", "tf"]), access: ReadWrite, mode_req: Any },
     // --- Pedals ---
-    // The driver reports pedals raw and exposes no curve/deadzone/combined
-    // attributes, so there is nothing else to list here.
+    // Each pedal has three generators that all write the one 0x80A4 curve the
+    // pedal MCU applies to its axis (hardware-verified 2026-07-16). Last write
+    // wins; the curve attr reads back the true device state. mode_req Any: the
+    // driver's pedal stores do not gate on mode.
     SettingSpec { attr: "wheel_brake_force", label: "Brake force", help: "Load-cell brake threshold (0-100%). Onboard mode only.", category: Pedals, kind: PCT, access: ReadWrite, mode_req: OnboardOnly },
+    SettingSpec { attr: "wheel_throttle_curve", label: "Throttle curve", help: "Full throttle response curve. 'reset' for built-in.", category: Pedals, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_throttle_sensitivity", label: "Throttle sensitivity", help: "Throttle response (0-100, 50=linear).", category: Pedals, kind: PCT, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_throttle_deadzone", label: "Throttle deadzone", help: "Dead travel 'lower upper' percent (sum <= 99).", category: Pedals, kind: Kind::Pair { max: 99 }, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_brake_curve", label: "Brake curve", help: "Full brake response curve. 'reset' for built-in.", category: Pedals, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_brake_sensitivity", label: "Brake sensitivity", help: "Brake response (0-100, 50=linear).", category: Pedals, kind: PCT, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_brake_deadzone", label: "Brake deadzone", help: "Dead travel 'lower upper' percent (sum <= 99).", category: Pedals, kind: Kind::Pair { max: 99 }, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_clutch_curve", label: "Clutch curve", help: "Full clutch response curve. 'reset' for built-in.", category: Pedals, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_clutch_sensitivity", label: "Clutch sensitivity", help: "Clutch response (0-100, 50=linear).", category: Pedals, kind: PCT, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_clutch_deadzone", label: "Clutch deadzone", help: "Dead travel 'lower upper' percent (sum <= 99).", category: Pedals, kind: Kind::Pair { max: 99 }, access: ReadWrite, mode_req: Any },
     // --- LEDs (RS50 LIGHTSYNC) ---
     SettingSpec { attr: "wheel_led_brightness", label: "LED brightness", help: "Global LED brightness (0-100%).", category: Leds, kind: PCT, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_led_effect", label: "LED effect", help: "Animation mode (1-9).", category: Leds, kind: Kind::IntRange { min: 1, max: 9, step: 1, unit: "" }, access: ReadWrite, mode_req: Any },
@@ -68,6 +79,7 @@ pub(crate) fn sample_raw(s: &SettingSpec) -> String {
         Kind::TextField { .. } => "RACE".into(),
         Kind::RgbStrip { leds } => vec!["000000"; leds].join(" "),
         Kind::Curve => "reset".into(),
+        Kind::Pair { .. } => "0 0".into(),
         Kind::Action => "1".into(),
         Kind::SlotText { slots, .. } => {
             (1..=slots).map(|i| format!("{i}: NAME{i}")).collect::<Vec<_>>().join("\n")

--- a/userspace/logi-dd/crates/logi-dd-core/src/value.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/value.rs
@@ -32,6 +32,8 @@ pub enum Value {
     Text(String),
     Rgb(Vec<Color>),
     Curve(Vec<(u16, u16)>),
+    /// A `(lower, upper)` percent pair, e.g. a pedal deadzone.
+    Pair(u8, u8),
     Trigger,
     /// Every slot name, as read back (index 0 = slot 1).
     SlotNames(Vec<String>),

--- a/userspace/logi-dd/crates/logi-dd-tui/src/app.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/app.rs
@@ -1,7 +1,8 @@
+use crate::curve_editor::CurveEditor;
 use crate::edit;
 use logi_dd_core::setting::Access;
 use logi_dd_core::sysfs::SysfsIo;
-use logi_dd_core::{Category, Device, Error, Mode, Value, REGISTRY};
+use logi_dd_core::{Category, Device, Error, Kind, Mode, Value, REGISTRY};
 use std::collections::BTreeMap;
 
 pub struct Row {
@@ -18,6 +19,8 @@ pub struct App<S: SysfsIo> {
     pub rows: Vec<Row>,
     pub status: String,
     pub edit: Option<edit::EditState>,
+    /// The modal curve editor, active while shaping a `Kind::Curve` attribute.
+    pub curve_edit: Option<CurveEditor>,
     pub quit: bool,
 }
 
@@ -30,6 +33,7 @@ impl<S: SysfsIo> App<S> {
             rows: Vec::new(),
             status: String::new(),
             edit: None,
+            curve_edit: None,
             quit: false,
         };
         a.reload();
@@ -100,7 +104,28 @@ impl<S: SysfsIo> App<S> {
                 return;
             }
         };
+        // Curves get the modal point-list editor; everything else the inline
+        // field editor.
+        if matches!(spec.kind, Kind::Curve) {
+            self.curve_edit = Some(CurveEditor::from_value(spec.attr, &cur));
+            return;
+        }
         self.edit = Some(edit::EditState::start(spec.attr, spec.kind, &cur));
+    }
+
+    pub fn commit_curve_edit(&mut self) {
+        let Some(ed) = self.curve_edit.take() else { return };
+        let attr = ed.attr;
+        let label = Device::<S>::spec(attr).map(|s| s.label).unwrap_or(attr);
+        match self.device.write(attr, &ed.to_value()) {
+            Ok(()) => self.status = format!("{label} set ({} points)", ed.point_count()),
+            Err(Error::WrongMode { needed }) => {
+                let m = if needed == Mode::Desktop { "desktop" } else { "onboard" };
+                self.status = format!("needs {m} mode: press 'd' to toggle, then retry");
+            }
+            Err(err) => self.status = format!("{label}: {err}"),
+        }
+        self.reload();
     }
 
     /// Switch the wheel between desktop and onboard mode (the `d` shortcut).
@@ -152,6 +177,20 @@ impl<S: SysfsIo> App<S> {
 
     pub fn on_key(&mut self, key: crossterm::event::KeyCode) {
         use crossterm::event::KeyCode::*;
+        if let Some(ce) = self.curve_edit.as_mut() {
+            match key {
+                Enter => self.commit_curve_edit(),
+                Esc => self.curve_edit = None,
+                Up => ce.prev_field(),
+                Down => ce.next_field(),
+                Left => ce.adjust(-1),
+                Right => ce.adjust(1),
+                Char('+') => ce.add_point(),
+                Char('-') => ce.delete_point(),
+                _ => {}
+            }
+            return;
+        }
         if let Some(ed) = self.edit.as_mut() {
             match key {
                 Enter => self.commit_edit(),
@@ -253,6 +292,61 @@ mod tests {
         assert_eq!(a.device.current_mode().unwrap(), Mode::Onboard);
         a.on_key(KeyCode::Char('d'));
         assert_eq!(a.device.current_mode().unwrap(), Mode::Desktop);
+    }
+
+    fn pedal_app() -> App<FakeSysfs> {
+        let fs = FakeSysfs::new();
+        fs.set("wheel_throttle_curve", "0/64 points loaded (0 = built-in curve)");
+        let mut a = App::new(logi_dd_core::Device::with_io(fs));
+        a.cat_idx = Category::ALL.iter().position(|c| *c == Category::Pedals).unwrap();
+        a.reload();
+        a.row_idx = a.rows.iter().position(|r| r.attr == "wheel_throttle_curve").unwrap();
+        a
+    }
+
+    #[test]
+    fn curve_row_opens_modal_not_inline_editor() {
+        use crossterm::event::KeyCode;
+        let mut a = pedal_app();
+        a.on_key(KeyCode::Enter);
+        assert!(a.curve_edit.is_some(), "curve opens the modal editor");
+        assert!(a.edit.is_none(), "not the inline field editor");
+    }
+
+    #[test]
+    fn curve_editor_commit_writes_a_multipoint_curve() {
+        use crossterm::event::KeyCode;
+        let mut a = pedal_app();
+        a.on_key(KeyCode::Enter); // open
+        a.on_key(KeyCode::Char('+')); // add a middle point (now 3 points)
+        a.on_key(KeyCode::Down); // move to Output field
+        a.on_key(KeyCode::Right); // bend the point
+        a.on_key(KeyCode::Enter); // save
+        assert!(a.curve_edit.is_none());
+        assert!(a.status.contains("set"), "status: {}", a.status);
+        // the stored curve is a real multi-point list ending at full scale
+        match a.device.read("wheel_throttle_curve").unwrap() {
+            Value::Curve(pts) => {
+                assert!(pts.len() >= 3, "points: {pts:?}");
+                assert_eq!(*pts.last().unwrap(), (65535, 65535));
+            }
+            v => panic!("expected a curve, got {v:?}"),
+        }
+    }
+
+    #[test]
+    fn curve_editor_esc_cancels_without_writing() {
+        use crossterm::event::KeyCode;
+        let mut a = pedal_app();
+        a.on_key(KeyCode::Enter);
+        a.on_key(KeyCode::Char('+'));
+        a.on_key(KeyCode::Esc);
+        assert!(a.curve_edit.is_none());
+        // nothing was written: the store still reads built-in (empty curve)
+        assert_eq!(
+            a.device.read("wheel_throttle_curve").unwrap(),
+            Value::Curve(vec![])
+        );
     }
 
     #[test]

--- a/userspace/logi-dd/crates/logi-dd-tui/src/curve_editor.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/curve_editor.rs
@@ -1,0 +1,434 @@
+//! A G HUB-style point-list curve editor for the pedal/steering response
+//! curves. The user edits control points (input/output percent) plus lower and
+//! upper deadzones; `compose` turns those into the `in:out` point list the
+//! driver's 0x80A4 uploader takes, and `render` draws a live ASCII preview.
+//!
+//! The wheel does not report a loaded curve's points back (only the count), so
+//! this authors curves rather than round-tripping them: an editor opened on an
+//! already-shaped axis starts from the value it was handed, defaulting to
+//! linear.
+
+use logi_dd_core::Value;
+
+const FULL: u16 = 65535;
+/// One percent of full scale, the step for input/output nudges.
+const PCT: i32 = 655;
+
+/// Which field the arrow keys act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Field {
+    Point,
+    Input,
+    Output,
+    Lower,
+    Upper,
+}
+
+impl Field {
+    const ORDER: [Field; 5] =
+        [Field::Point, Field::Input, Field::Output, Field::Lower, Field::Upper];
+    pub fn label(&self) -> &'static str {
+        match self {
+            Field::Point => "Point",
+            Field::Input => "Input",
+            Field::Output => "Output",
+            Field::Lower => "Lower deadzone",
+            Field::Upper => "Upper deadzone",
+        }
+    }
+}
+
+pub struct CurveEditor {
+    pub attr: &'static str,
+    /// Control points, always sorted by input with `pts[0].0 == 0` and
+    /// `pts[last].0 == FULL`; outputs non-decreasing.
+    pub pts: Vec<(u16, u16)>,
+    pub lower_dz: u8,
+    pub upper_dz: u8,
+    pub sel: usize,
+    pub field: Field,
+}
+
+/// Round a 0..=65535 value to a whole percent for display.
+pub fn to_pct(v: u16) -> u32 {
+    (v as u32 * 100 + (FULL as u32 / 2)) / FULL as u32
+}
+
+impl CurveEditor {
+    /// Seed from a value. A non-empty curve loads its points; anything else
+    /// (built-in / empty) starts from linear. Deadzones start at zero since the
+    /// device does not report them back.
+    pub fn from_value(attr: &'static str, v: &Value) -> CurveEditor {
+        let pts = match v {
+            Value::Curve(p) if p.len() >= 2 => p.clone(),
+            _ => vec![(0, 0), (FULL, FULL)],
+        };
+        CurveEditor { attr, pts, lower_dz: 0, upper_dz: 0, sel: 0, field: Field::Point }
+    }
+
+    pub fn point_count(&self) -> usize {
+        self.pts.len()
+    }
+
+    /// Compose the final `in:out` curve for upload: the control points remapped
+    /// into the live input band `[lower, 100-upper]`, with flat dead/saturated
+    /// segments outside it. Always returns a driver-valid curve (strictly
+    /// increasing inputs, non-decreasing outputs, pinned 0:0 and FULL:FULL).
+    pub fn compose(&self) -> Vec<(u16, u16)> {
+        let lo = (self.lower_dz as u32 * FULL as u32 / 100) as u16;
+        let hi = ((100 - self.upper_dz as u32) * FULL as u32 / 100) as u16;
+        let span = hi.saturating_sub(lo) as u32;
+
+        let mut out: Vec<(u16, u16)> = Vec::with_capacity(self.pts.len() + 2);
+        if self.lower_dz > 0 {
+            push_pt(&mut out, 0, 0);
+        }
+        for &(inp, outp) in &self.pts {
+            let mapped = lo as u32 + (inp as u32 * span / FULL as u32);
+            push_pt(&mut out, mapped as u16, outp);
+        }
+        if self.upper_dz > 0 {
+            push_pt(&mut out, FULL, FULL);
+        }
+
+        // Guarantee the pinned endpoints the uploader demands.
+        if out.first().map(|p| p.0) != Some(0) {
+            out.insert(0, (0, 0));
+        }
+        if out.last().map(|p| p.0) != Some(FULL) {
+            push_pt(&mut out, FULL, FULL);
+        }
+        out
+    }
+
+    pub fn to_value(&self) -> Value {
+        Value::Curve(self.compose())
+    }
+
+    pub fn next_field(&mut self) {
+        let i = Field::ORDER.iter().position(|f| *f == self.field).unwrap_or(0);
+        self.field = Field::ORDER[(i + 1) % Field::ORDER.len()];
+    }
+
+    pub fn prev_field(&mut self) {
+        let i = Field::ORDER.iter().position(|f| *f == self.field).unwrap_or(0);
+        self.field = Field::ORDER[(i + Field::ORDER.len() - 1) % Field::ORDER.len()];
+    }
+
+    /// Left/right on the current field.
+    pub fn adjust(&mut self, d: i32) {
+        match self.field {
+            Field::Point => {
+                let n = self.pts.len() as i32;
+                self.sel = (self.sel as i32 + d).clamp(0, n - 1) as usize;
+            }
+            Field::Input => self.move_input(d * PCT),
+            Field::Output => self.move_output(d * PCT),
+            Field::Lower => {
+                self.lower_dz = (self.lower_dz as i32 + d)
+                    .clamp(0, 99 - self.upper_dz as i32) as u8;
+            }
+            Field::Upper => {
+                self.upper_dz = (self.upper_dz as i32 + d)
+                    .clamp(0, 99 - self.lower_dz as i32) as u8;
+            }
+        }
+    }
+
+    /// Move the selected point's input, clamped strictly between its
+    /// neighbours. The two endpoints' inputs are pinned (0 and FULL).
+    fn move_input(&mut self, delta: i32) {
+        let last = self.pts.len() - 1;
+        if self.sel == 0 || self.sel == last {
+            return;
+        }
+        let lo = self.pts[self.sel - 1].0 as i32 + 1;
+        let hi = self.pts[self.sel + 1].0 as i32 - 1;
+        if lo > hi {
+            return;
+        }
+        let cur = self.pts[self.sel].0 as i32;
+        self.pts[self.sel].0 = (cur + delta).clamp(lo, hi) as u16;
+    }
+
+    /// Move the selected point's output, clamped so outputs stay non-decreasing.
+    fn move_output(&mut self, delta: i32) {
+        let last = self.pts.len() - 1;
+        let lo = if self.sel == 0 { 0 } else { self.pts[self.sel - 1].1 as i32 };
+        let hi = if self.sel == last { FULL as i32 } else { self.pts[self.sel + 1].1 as i32 };
+        let cur = self.pts[self.sel].1 as i32;
+        self.pts[self.sel].1 = (cur + delta).clamp(lo, hi) as u16;
+    }
+
+    /// Insert a point midway between the selected point and the next one, and
+    /// select it. No-op on the last point (nothing to bisect toward).
+    pub fn add_point(&mut self) {
+        let last = self.pts.len() - 1;
+        if self.sel >= last {
+            return;
+        }
+        let (ai, ao) = self.pts[self.sel];
+        let (bi, bo) = self.pts[self.sel + 1];
+        if bi - ai < 2 {
+            return; // no room for a distinct input between them
+        }
+        let mid = ((ai as u32 + bi as u32) / 2) as u16;
+        let mout = ((ao as u32 + bo as u32) / 2) as u16;
+        self.pts.insert(self.sel + 1, (mid, mout));
+        self.sel += 1;
+        self.field = Field::Input;
+    }
+
+    /// Delete the selected point. Endpoints cannot be deleted.
+    pub fn delete_point(&mut self) {
+        let last = self.pts.len() - 1;
+        if self.sel == 0 || self.sel == last || self.pts.len() <= 2 {
+            return;
+        }
+        self.pts.remove(self.sel);
+        if self.sel > self.pts.len() - 1 {
+            self.sel = self.pts.len() - 1;
+        }
+    }
+
+    /// Value shown for any field (for rendering the whole panel).
+    pub fn value_of(&self, f: Field) -> String {
+        match f {
+            Field::Point => format!("{} / {}", self.sel + 1, self.pts.len()),
+            Field::Input => format!("{}%", to_pct(self.pts[self.sel].0)),
+            Field::Output => format!("{}%", to_pct(self.pts[self.sel].1)),
+            Field::Lower => format!("{}%", self.lower_dz),
+            Field::Upper => format!("{}%", self.upper_dz),
+        }
+    }
+
+    pub const FIELDS: [Field; 5] = Field::ORDER;
+
+    /// Render the composed curve as an ASCII plot `h` rows by `w` cols. Input on
+    /// X (0 left, full right), output on Y (0 bottom, full top). The selected
+    /// control point is marked `@`, other plotted cells `*`.
+    pub fn render(&self, w: usize, h: usize) -> Vec<String> {
+        let w = w.max(8);
+        let h = h.max(4);
+        let mut grid = vec![vec![b' '; w]; h];
+        let curve = self.compose();
+
+        let col = |inp: u16| ((inp as usize * (w - 1)) / FULL as usize).min(w - 1);
+        let row = |outp: u16| (h - 1) - ((outp as usize * (h - 1)) / FULL as usize).min(h - 1);
+
+        // Plot the composed curve by walking each column's input to its output.
+        // Indexing grid[y][x] with a computed y rules out an iterator loop.
+        #[allow(clippy::needless_range_loop)]
+        for x in 0..w {
+            let inp = ((x * FULL as usize) / (w - 1)) as u32;
+            let outp = interp(&curve, inp.min(FULL as u32) as u16);
+            let y = row(outp);
+            grid[y][x] = b'*';
+        }
+        // Mark the selected control point (mapped through the deadzones).
+        let (si, so) = self.pts[self.sel];
+        let lo = (self.lower_dz as u32 * FULL as u32 / 100) as u16;
+        let hi = ((100 - self.upper_dz as u32) * FULL as u32 / 100) as u16;
+        let span = hi.saturating_sub(lo) as u32;
+        let mapped = lo as u32 + (si as u32 * span / FULL as u32);
+        grid[row(so)][col(mapped as u16)] = b'@';
+
+        grid.into_iter().map(|r| String::from_utf8(r).unwrap()).collect()
+    }
+}
+
+/// Append `(inp, outp)`, keeping inputs strictly increasing. A collision means
+/// the deadzone remap folded two control points onto one input, so keep the
+/// higher output rather than emitting a duplicate the uploader would reject.
+fn push_pt(out: &mut Vec<(u16, u16)>, inp: u16, outp: u16) {
+    match out.last() {
+        Some(&(pi, po)) if pi >= inp => {
+            if outp > po {
+                let n = out.len() - 1;
+                out[n] = (pi, outp);
+            }
+        }
+        _ => out.push((inp, outp)),
+    }
+}
+
+/// Linear interpolation of a sorted `in:out` curve at input `x`.
+fn interp(curve: &[(u16, u16)], x: u16) -> u16 {
+    if curve.is_empty() {
+        return x;
+    }
+    if x <= curve[0].0 {
+        return curve[0].1;
+    }
+    for w in curve.windows(2) {
+        let (x0, y0) = w[0];
+        let (x1, y1) = w[1];
+        if x <= x1 {
+            if x1 == x0 {
+                return y1;
+            }
+            let t = (x as u32 - x0 as u32) * (y1 as u32 - y0 as u32) / (x1 as u32 - x0 as u32);
+            return (y0 as u32 + t) as u16;
+        }
+    }
+    curve.last().unwrap().1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linear() -> CurveEditor {
+        CurveEditor::from_value("wheel_throttle_curve", &Value::Curve(vec![]))
+    }
+
+    fn is_valid(curve: &[(u16, u16)]) {
+        assert!(curve.len() >= 2, "need >=2 points");
+        assert_eq!(curve[0], (0, 0), "must start 0:0");
+        assert_eq!(*curve.last().unwrap(), (FULL, FULL), "must end FULL:FULL");
+        for w in curve.windows(2) {
+            assert!(w[1].0 > w[0].0, "inputs strictly increasing: {:?}", curve);
+            assert!(w[1].1 >= w[0].1, "outputs non-decreasing: {:?}", curve);
+        }
+    }
+
+    #[test]
+    fn default_is_linear_two_points() {
+        let e = linear();
+        assert_eq!(e.pts, vec![(0, 0), (FULL, FULL)]);
+        is_valid(&e.compose());
+    }
+
+    #[test]
+    fn add_point_bisects_and_selects() {
+        let mut e = linear();
+        e.add_point();
+        assert_eq!(e.pts.len(), 3);
+        assert_eq!(e.sel, 1);
+        assert_eq!(e.pts[1], (FULL / 2, FULL / 2));
+        is_valid(&e.compose());
+    }
+
+    #[test]
+    fn endpoints_inputs_are_pinned() {
+        let mut e = linear();
+        e.sel = 0;
+        e.field = Field::Input;
+        e.adjust(10);
+        assert_eq!(e.pts[0].0, 0, "first input stays 0");
+        e.sel = 1;
+        e.adjust(-10);
+        assert_eq!(e.pts[1].0, FULL, "last input stays FULL");
+    }
+
+    #[test]
+    fn middle_input_clamps_between_neighbours() {
+        let mut e = linear();
+        e.add_point(); // point at (32767, 32767), sel=1
+        e.field = Field::Input;
+        // shove far right: cannot pass the last point's input
+        e.adjust(1000);
+        assert!(e.pts[1].0 < FULL);
+        assert!(e.pts[1].0 > e.pts[0].0);
+        is_valid(&e.compose());
+    }
+
+    #[test]
+    fn output_stays_monotonic() {
+        let mut e = linear();
+        e.add_point(); // sel=1, mid
+        e.field = Field::Output;
+        e.adjust(1000); // raise well above the neighbours
+        e.adjust(-1000); // and back down; must never cross a neighbour
+        is_valid(&e.compose());
+    }
+
+    #[test]
+    fn delete_removes_middle_only() {
+        let mut e = linear();
+        e.add_point();
+        assert_eq!(e.pts.len(), 3);
+        e.sel = 1;
+        e.delete_point();
+        assert_eq!(e.pts.len(), 2);
+        // endpoints can't be deleted
+        e.sel = 0;
+        e.delete_point();
+        e.sel = 1;
+        e.delete_point();
+        assert_eq!(e.pts.len(), 2);
+    }
+
+    #[test]
+    fn lower_deadzone_holds_output_zero() {
+        let mut e = linear();
+        e.lower_dz = 20;
+        let c = e.compose();
+        is_valid(&c);
+        // at 10% input (below the 20% deadzone) output must still be 0
+        assert_eq!(interp(&c, (FULL as u32 / 10) as u16), 0);
+        // at 60% input output should be well above 0
+        assert!(interp(&c, (FULL as u32 * 6 / 10) as u16) > 0);
+    }
+
+    #[test]
+    fn upper_deadzone_saturates_early() {
+        let mut e = linear();
+        e.upper_dz = 20;
+        let c = e.compose();
+        is_valid(&c);
+        // by 85% input (past the 80% saturation point) output is full
+        assert_eq!(interp(&c, (FULL as u32 * 85 / 100) as u16), FULL);
+    }
+
+    #[test]
+    fn deadzones_cannot_sum_over_99() {
+        let mut e = linear();
+        e.field = Field::Lower;
+        for _ in 0..200 {
+            e.adjust(1);
+        }
+        assert_eq!(e.lower_dz, 99);
+        e.field = Field::Upper;
+        e.adjust(1);
+        assert_eq!(e.upper_dz, 0, "upper cannot grow while lower is 99");
+    }
+
+    #[test]
+    fn field_cycle_wraps() {
+        let mut e = linear();
+        assert_eq!(e.field, Field::Point);
+        e.prev_field();
+        assert_eq!(e.field, Field::Upper);
+        e.next_field();
+        assert_eq!(e.field, Field::Point);
+    }
+
+    #[test]
+    fn render_has_requested_dimensions() {
+        let mut e = linear();
+        e.add_point();
+        e.sel = 1;
+        e.field = Field::Output;
+        e.adjust(20); // bend it
+        let rows = e.render(40, 10);
+        assert_eq!(rows.len(), 10);
+        assert!(rows.iter().all(|r| r.chars().count() == 40));
+        // the selected point marker is present
+        assert!(rows.iter().any(|r| r.contains('@')));
+    }
+
+    #[test]
+    fn composed_curve_always_driver_valid_under_edits() {
+        let mut e = linear();
+        e.add_point();
+        e.add_point();
+        e.field = Field::Output;
+        e.adjust(30);
+        e.field = Field::Lower;
+        e.adjust(10);
+        e.field = Field::Upper;
+        e.adjust(15);
+        is_valid(&e.compose());
+    }
+}

--- a/userspace/logi-dd/crates/logi-dd-tui/src/curve_editor.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/curve_editor.rs
@@ -91,13 +91,19 @@ impl CurveEditor {
             push_pt(&mut out, FULL, FULL);
         }
 
-        // Guarantee the pinned endpoints the uploader demands.
+        // Guarantee the pinned endpoints the uploader demands: it rejects any
+        // curve not starting exactly 0:0 and ending FULL:FULL. Pin both the
+        // inputs and the outputs, defensively, so a stray control point can
+        // never produce a curve the driver refuses.
         if out.first().map(|p| p.0) != Some(0) {
             out.insert(0, (0, 0));
         }
         if out.last().map(|p| p.0) != Some(FULL) {
             push_pt(&mut out, FULL, FULL);
         }
+        out[0].1 = 0;
+        let n = out.len() - 1;
+        out[n].1 = FULL;
         out
     }
 
@@ -152,10 +158,16 @@ impl CurveEditor {
     }
 
     /// Move the selected point's output, clamped so outputs stay non-decreasing.
+    /// The endpoint outputs are pinned (first at 0, last at FULL), like their
+    /// inputs: the driver's uploader requires the curve to start 0:0 and end
+    /// FULL:FULL, and the deadzones handle any dead/saturated ends.
     fn move_output(&mut self, delta: i32) {
         let last = self.pts.len() - 1;
-        let lo = if self.sel == 0 { 0 } else { self.pts[self.sel - 1].1 as i32 };
-        let hi = if self.sel == last { FULL as i32 } else { self.pts[self.sel + 1].1 as i32 };
+        if self.sel == 0 || self.sel == last {
+            return;
+        }
+        let lo = self.pts[self.sel - 1].1 as i32;
+        let hi = self.pts[self.sel + 1].1 as i32;
         let cur = self.pts[self.sel].1 as i32;
         self.pts[self.sel].1 = (cur + delta).clamp(lo, hi) as u16;
     }
@@ -319,6 +331,21 @@ mod tests {
         e.sel = 1;
         e.adjust(-10);
         assert_eq!(e.pts[1].0, FULL, "last input stays FULL");
+    }
+
+    #[test]
+    fn endpoint_outputs_are_pinned_so_compose_stays_valid() {
+        // Regression: raising the first point's output or lowering the last
+        // point's output must not produce a curve the driver rejects.
+        let mut e = linear();
+        e.field = Field::Output;
+        e.sel = 0;
+        e.adjust(5); // try to lift (0,0) -> (0, >0)
+        assert_eq!(e.pts[0].1, 0, "first output stays 0");
+        e.sel = 1;
+        e.adjust(-5); // try to drop (FULL,FULL) -> (FULL, <FULL)
+        assert_eq!(e.pts[1].1, FULL, "last output stays FULL");
+        is_valid(&e.compose());
     }
 
     #[test]

--- a/userspace/logi-dd/crates/logi-dd-tui/src/main.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod curve_editor;
 mod edit;
 mod ui;
 

--- a/userspace/logi-dd/crates/logi-dd-tui/src/ui.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/ui.rs
@@ -1,10 +1,11 @@
 use crate::app::App;
+use crate::curve_editor::CurveEditor;
 use logi_dd_core::sysfs::SysfsIo;
 use logi_dd_core::{Category, Device, Mode, Value};
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
 use ratatui::Frame;
 use std::collections::BTreeMap;
 
@@ -129,8 +130,15 @@ pub fn draw<S: SysfsIo>(f: &mut Frame, app: &App<S>) {
         body[1],
     );
 
+    // The curve editor takes over the body area as a modal when active.
+    if let Some(ce) = &app.curve_edit {
+        draw_curve_editor(f, ce, root[1]);
+    }
+
     // status line (green on success, red on trouble) + a dim help line
-    let help = if app.edit.is_some() {
+    let help = if app.curve_edit.is_some() {
+        "curve:  up/down field   <-/-> adjust   + add point   - delete   Enter save   Esc cancel"
+    } else if app.edit.is_some() {
         "editing:  <-/->  adjust    type  text    Enter  commit    Esc  cancel"
     } else {
         "up/down select   <-/-> category   Enter edit   d toggle desktop/onboard   r refresh   q quit"
@@ -146,6 +154,59 @@ pub fn draw<S: SysfsIo>(f: &mut Frame, app: &App<S>) {
         )),
     ];
     f.render_widget(Paragraph::new(lines), root[2]);
+}
+
+/// Render the modal curve editor over `area`: a left field panel and a right
+/// live ASCII preview of the composed curve.
+fn draw_curve_editor(f: &mut Frame, ce: &CurveEditor, area: Rect) {
+    f.render_widget(Clear, area);
+    let title = format!(" Curve editor: {} ", ce.attr.replace("wheel_", ""));
+    let outer = Block::default().borders(Borders::ALL).title(title);
+    let inner = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(30), Constraint::Min(10)])
+        .split(inner);
+
+    // Left: the editable fields, selected one highlighted.
+    let mut lines: Vec<Line> = CurveEditor::FIELDS
+        .iter()
+        .map(|fld| {
+            let selected = *fld == ce.field;
+            let marker = if selected { "> " } else { "  " };
+            let style = if selected {
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            Line::from(vec![
+                Span::styled(format!("{marker}{:<16}", fld.label()), style),
+                Span::styled(ce.value_of(*fld), style),
+            ])
+        })
+        .collect();
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "+ add point   - delete",
+        Style::default().fg(Color::DarkGray),
+    )));
+    f.render_widget(Paragraph::new(lines), cols[0]);
+
+    // Right: the ASCII curve, bordered, with 0%/100% guides.
+    let plot = Block::default().borders(Borders::ALL).title("output vs input");
+    let pinner = plot.inner(cols[1]);
+    f.render_widget(plot, cols[1]);
+    let (w, h) = (pinner.width as usize, pinner.height as usize);
+    if w >= 4 && h >= 2 {
+        let rows = ce.render(w, h);
+        let text: Vec<Line> = rows
+            .into_iter()
+            .map(|r| Line::from(Span::styled(r, Style::default().fg(Color::Cyan))))
+            .collect();
+        f.render_widget(Paragraph::new(text), pinner);
+    }
 }
 
 /// Render a profile number with its onboard slot name.


### PR DESCRIPTION
Restores G HUB-equivalent pedal shaping using the wheel's own hardware `0x80A4` response-curve feature on the pedal sub-device, and adds a G HUB-style curve editor to logi-dd.

## Why

The v0.14.0 removal of the pedal-curve attributes (and the whole HID-BPF detour) rested on **one untested capture** that concluded the pedal MCU stores `0x80A4` curves without applying them. That is **false**, proven on an RS50 this session: the pedal MCU (dev `0x02`, feature `0x0a`) applies the curve to the axis it reports to the PC, in desktop mode, exactly like the steering wheel.

## Hardware validation (all three pedals)

Artifact-proof tests, each producing an axis distribution a linear pedal cannot:

| Pedal | evdev | Test | Result |
|---|---|---|---|
| Throttle | ABS_RX | double-plateau curve | two dwell spikes at the programmed outputs, empty gap |
| Brake | ABS_RY | step curve (load-cell friendly) | bimodal, ~1.8% in the forbidden band |
| Clutch | ABS_RZ | step curve | bimodal, ~1.4% in the forbidden band |

Plus a full config-plane pass (all 9 attrs upload / read back / reset / reject bad input).

## What it adds

**Driver** — 9 sysfs attributes, three per pedal, all writing the one curve the axis holds (last write wins; `_curve` reads back the true device state):
- `wheel_<p>_curve` - raw `in:out` points or `reset`, mirrors `wheel_response_curve`
- `wheel_<p>_sensitivity` - the 0-100 G HUB slider (reuses the capture-verified steering Bezier, now extracted into a shared helper - confirmed byte-equivalent)
- `wheel_<p>_deadzone` - `"lower upper"` percent dead travel (sum <= 99)

**logi-dd** — a modal point-list curve editor for the pedal and steering curves (control points + deadzones, live ASCII preview), a new `Kind::Pair` for deadzones, and the 9 registry entries.

## Tests & review

- 37 core + 35 TUI Rust tests, clippy clean; driver builds clean (clang, kernel 7.1.3).
- The editor's `compose()` (points + deadzones -> driver-valid curve) is covered by pure-function unit tests.
- An adversarial code review caught one real bug (endpoint outputs not pinned -> `-EINVAL` on a common edit) and one minor (stale deadzone readback after replug); both fixed with a regression test.

## Not in this PR

- Combined pedals (protocol known: `0x0e` fn1) - a follow-up.
- logi-dd end-to-end on hardware - to be validated next.
