### PR TITLE
logi-dd: fix action-attr read + firmware line, merge categories

### DIFF
--- a/userspace/logi-dd/crates/logi-dd-core/src/device.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/device.rs
@@ -56,13 +56,19 @@ impl<S: SysfsIo> Device<S> {
         };
         Ok(DeviceInfo {
             serial: read("wheel_serial"),
-            firmware: read("wheel_firmware"),
+            // The driver returns "base: ...\nmotor: ..."; keep it on one line.
+            firmware: read("wheel_firmware").replace('\n', " / "),
             mode: self.current_mode()?,
         })
     }
 
     pub fn read(&self, attr: &str) -> Result<Value, Error> {
         let spec = Self::spec(attr).ok_or(Error::Invalid)?;
+        // Action attributes are write-only triggers; reading the sysfs file
+        // returns EACCES. Report the trigger value instead of a permission error.
+        if spec.access == Access::Action {
+            return Ok(Value::Trigger);
+        }
         let raw = self.io.read(attr).map_err(|e| map_io_error(&e, attr))?;
         // wheel_mode / wheel_texture_route report words; map to the enum index.
         if let Kind::Enum(variants) = spec.kind {
@@ -141,6 +147,29 @@ mod tests {
     fn texture_route_word_parses_to_enum() {
         // driver reports "tf"; registry models it as Enum index 1
         assert_eq!(dev().read("wheel_texture_route").unwrap(), Value::Enum(1));
+    }
+
+    #[test]
+    fn action_attrs_read_as_trigger_not_permission_error() {
+        // wheel_led_apply / wheel_calibrate_here are write-only (0220); reading
+        // the file gives EACCES. read() must report the trigger, not the error.
+        let fs = FakeSysfs::new();
+        fs.set_errno("wheel_led_apply", 13); // EACCES if it tried to read
+        let d = Device::with_io(fs);
+        assert_eq!(d.read("wheel_led_apply").unwrap(), Value::Trigger);
+        // even with the file entirely absent
+        assert_eq!(d.read("wheel_calibrate_here").unwrap(), Value::Trigger);
+    }
+
+    #[test]
+    fn firmware_info_is_single_line() {
+        let fs = FakeSysfs::new();
+        fs.set("wheel_mode", "desktop");
+        fs.set("wheel_serial", "X");
+        fs.set("wheel_firmware", "base: U1 65.04.B0039\nmotor: SC 02.01.B0042\n");
+        let info = Device::with_io(fs).info().unwrap();
+        assert!(!info.firmware.contains('\n'), "firmware: {:?}", info.firmware);
+        assert_eq!(info.firmware, "base: U1 65.04.B0039 / motor: SC 02.01.B0042");
     }
 
     #[test]

--- a/userspace/logi-dd/crates/logi-dd-core/src/kind.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/kind.rs
@@ -179,7 +179,9 @@ impl Kind {
             (Kind::Toggle { off, on }, Value::Bool(b)) => {
                 (if *b { *on } else { *off }).to_string()
             }
-            (Kind::TextField { .. }, Value::Text(s)) => s.clone(),
+            // Collapse newlines so a multi-line value (e.g. the two-part
+            // firmware string) renders on the single line the TUI gives it.
+            (Kind::TextField { .. }, Value::Text(s)) => s.replace('\n', " / "),
             (Kind::RgbStrip { .. }, Value::Rgb(cs)) => format!("{} LEDs", cs.len()),
             (Kind::Curve, Value::Curve(p)) if p.is_empty() => "built-in".into(),
             (Kind::Curve, Value::Curve(p)) => format!("{} points", p.len()),

--- a/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
@@ -16,17 +16,17 @@ pub const REGISTRY: &[SettingSpec] = &[
     SettingSpec { attr: "wheel_spring_damping", label: "Spring damping", help: "Anti-oscillation damping on the emulated spring (0-100%).", category: Ffb, kind: PCT, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_ffb_constant_sign", label: "Invert constant force", help: "Flip the sign of constant forces (Wine/native fix).", category: Ffb, kind: Kind::Toggle { off: "normal", on: "inverted" }, access: ReadWrite, mode_req: Any },
     // --- Rotation ---
-    SettingSpec { attr: "wheel_range", label: "Rotation range", help: "Steering rotation (90-2700 deg).", category: Rotation, kind: Kind::IntRange { min: 90, max: 2700, step: 10, unit: "deg" }, access: ReadWrite, mode_req: Any },
-    SettingSpec { attr: "wheel_range_restore", label: "Auto range restore", help: "Auto-recover from a launch-time 90-degree reset.", category: Rotation, kind: Kind::Toggle { off: "off", on: "on" }, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_range", label: "Rotation range", help: "Steering rotation (90-2700 deg).", category: Steering, kind: Kind::IntRange { min: 90, max: 2700, step: 10, unit: "deg" }, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_range_restore", label: "Auto range restore", help: "Auto-recover from a launch-time 90-degree reset.", category: Steering, kind: Kind::Toggle { off: "off", on: "on" }, access: ReadWrite, mode_req: Any },
     // --- Sensitivity ---
-    SettingSpec { attr: "wheel_sensitivity", label: "Sensitivity", help: "Steering response (0-100%, 50=built-in). Desktop mode only.", category: Sensitivity, kind: PCT, access: ReadWrite, mode_req: DesktopOnly },
+    SettingSpec { attr: "wheel_sensitivity", label: "Sensitivity", help: "Steering response (0-100%, 50=built-in). Desktop mode only.", category: Steering, kind: PCT, access: ReadWrite, mode_req: DesktopOnly },
     // Any, not DesktopOnly: unlike wheel_sensitivity, the driver's
     // wheel_response_curve_store does not gate on mode (no -EPERM), so a
     // DesktopOnly pre-check would falsely reject onboard-mode writes.
-    SettingSpec { attr: "wheel_response_curve", label: "Response curve", help: "Full steering response curve. 'reset' for built-in.", category: Sensitivity, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_response_curve", label: "Response curve", help: "Full steering response curve. 'reset' for built-in.", category: Steering, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
     // --- TrueForce ---
-    SettingSpec { attr: "wheel_trueforce", label: "TrueForce intensity", help: "Audio-haptic texture intensity (0-100%).", category: TrueForce, kind: PCT, access: ReadWrite, mode_req: Any },
-    SettingSpec { attr: "wheel_texture_route", label: "Texture routing", help: "Route rumble/texture to TrueForce (tf) or steering (kf).", category: TrueForce, kind: Kind::Enum(&["kf", "tf"]), access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_trueforce", label: "TrueForce intensity", help: "Audio-haptic texture intensity (0-100%).", category: Ffb, kind: PCT, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_texture_route", label: "Texture routing", help: "Route rumble/texture to TrueForce (tf) or steering (kf).", category: Ffb, kind: Kind::Enum(&["kf", "tf"]), access: ReadWrite, mode_req: Any },
     // --- Pedals ---
     // Each pedal has three generators that all write the one 0x80A4 curve the
     // pedal MCU applies to its axis (hardware-verified 2026-07-16). Last write
@@ -61,7 +61,7 @@ pub const REGISTRY: &[SettingSpec] = &[
     // uppercased.
     SettingSpec { attr: "wheel_profile_names", label: "Profile names", help: "Rename an onboard slot: left/right picks the slot, type a name (1-9 chars, stored uppercase).", category: Profiles, kind: Kind::SlotText { slots: 5, max_len: 9 }, access: ReadWrite, mode_req: Any },
     // --- Calibration ---
-    SettingSpec { attr: "wheel_calibrate_here", label: "Calibrate centre here", help: "Adopt the current physical position as centre.", category: Calibration, kind: Kind::Action, access: Action, mode_req: Any },
+    SettingSpec { attr: "wheel_calibrate_here", label: "Calibrate centre here", help: "Adopt the current physical position as centre.", category: Steering, kind: Kind::Action, access: Action, mode_req: Any },
     // --- Info ---
     SettingSpec { attr: "wheel_serial", label: "Serial", help: "Device serial number.", category: Info, kind: Kind::TextField { max_len: 32 }, access: ReadOnly, mode_req: Any },
     SettingSpec { attr: "wheel_firmware", label: "Firmware", help: "Base and motor firmware versions.", category: Info, kind: Kind::TextField { max_len: 128 }, access: ReadOnly, mode_req: Any },

--- a/userspace/logi-dd/crates/logi-dd-core/src/setting.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/setting.rs
@@ -3,38 +3,33 @@ use crate::kind::Kind;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Category {
     Ffb,
-    Rotation,
-    Sensitivity,
-    TrueForce,
+    Steering,
     Pedals,
     Leds,
     Profiles,
-    Calibration,
     Info,
 }
 
 impl Category {
     pub const ALL: &'static [Category] = &[
         Category::Ffb,
-        Category::Rotation,
-        Category::Sensitivity,
-        Category::TrueForce,
+        Category::Steering,
         Category::Pedals,
         Category::Leds,
         Category::Profiles,
-        Category::Calibration,
         Category::Info,
     ];
     pub fn label(&self) -> &'static str {
         match self {
+            // Ffb folds in TrueForce (a haptic layer of the same force path).
             Category::Ffb => "Force feedback",
-            Category::Rotation => "Rotation",
-            Category::Sensitivity => "Sensitivity",
-            Category::TrueForce => "TrueForce",
+            // Steering folds in the old Rotation, Sensitivity and Calibration:
+            // range, response curve, sensitivity and centre calibration are all
+            // the one steering axis.
+            Category::Steering => "Steering",
             Category::Pedals => "Pedals",
             Category::Leds => "LEDs",
             Category::Profiles => "Profiles / mode",
-            Category::Calibration => "Calibration",
             Category::Info => "Info",
         }
     }

--- a/userspace/logi-dd/crates/logi-dd-tui/src/app.rs
+++ b/userspace/logi-dd/crates/logi-dd-tui/src/app.rs
@@ -273,7 +273,7 @@ mod tests {
         fs.set("wheel_mode", "onboard");
         fs.set("wheel_sensitivity", "50");
         let mut a = App::new(logi_dd_core::Device::with_io(fs));
-        a.cat_idx = Category::ALL.iter().position(|c| *c == Category::Sensitivity).unwrap();
+        a.cat_idx = Category::ALL.iter().position(|c| *c == Category::Steering).unwrap();
         a.reload();
         a.row_idx = a.rows.iter().position(|r| r.attr == "wheel_sensitivity").unwrap();
         a.on_key(KeyCode::Enter);


### PR DESCRIPTION
Fixes three issues found while using logi-dd on a live wheel, plus a category tidy-up.

## Fixes

- **Action attributes showed "Permission denied".** `wheel_led_apply` and `wheel_calibrate_here` are write-only (`0220`); the row-value read hit them and surfaced EACCES. `Device::read` now short-circuits `Access::Action` and returns the trigger value, so those rows render normally and Enter still runs them.
- **Firmware ran together as "B0039motor".** The driver returns `base: ...\nmotor: ...`; on the TUI's single line the newline was dropped, gluing the two halves. Collapse newlines to ` / ` in the firmware info and in `TextField` display → `base: U1 65.04.B0039 / motor: SC 02.01.B0042`.
- **Category merge.** The sparse categories are consolidated: Rotation + Sensitivity + Calibration → **Steering** (range, response curve, sensitivity, centre calibration are all the one axis), and TrueForce → **Force feedback**. Nine categories become six.

## Not a bug

The pedal-curve `<could not read value: 0/64 points loaded...>` was a **stale binary**, not a code defect: current code reads all three pedal curves fine on an RS50 (`Curve([])`). Rebuilding `logi-dd-tui` resolves it.

## Tests

39 core + 35 TUI tests, clippy clean. New tests cover the action-read short-circuit and the single-line firmware.
