### PR TITLE
Combined pedals + RS Shifter & Handbrake support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ the contract is "it works on RS50 and G Pro as listed here".
 ## Unreleased
 
 ### Added
+- **Combined pedals.** `wheel_combined_pedals` (0/1, desktop only) toggles G HUB's
+  legacy throttle+brake axis merge via feature `0x80D0`. Verified on an RS50: on,
+  the two pedals collapse to a single centred axis (`ABS_RX` re-centres, `ABS_RY`
+  goes silent); off restores separate axes. Wired into logi-dd. The **RS Shifter
+  & Handbrake** accessory needs no driver change: its inputs ride the wheel's
+  existing report (analog handbrake = `ABS_Z`, verified).
 - **Hardware pedal shaping.** The pedal unit (HID++ sub-device `0x02`) applies a
   `0x80A4` response curve to each axis it reports to the PC, the same mechanism
   as the steering wheel. Verified on an RS50 for all three pedals with an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ the contract is "it works on RS50 and G Pro as listed here".
 - **Combined pedals.** `wheel_combined_pedals` (0/1, desktop only) toggles G HUB's
   legacy throttle+brake axis merge via feature `0x80D0`. Verified on an RS50: on,
   the two pedals collapse to a single centred axis (`ABS_RX` re-centres, `ABS_RY`
-  goes silent); off restores separate axes. Wired into logi-dd. The **RS Shifter
-  & Handbrake** accessory needs no driver change: its inputs ride the wheel's
-  existing report (analog handbrake = `ABS_Z`, verified).
+  goes silent); off restores separate axes. Wired into logi-dd.
+- **RS Shifter & Handbrake support.** All modes work with no driver change (they
+  ride the wheel's existing report): sequential shift = `BTN_TOP2` / `BTN_PINKIE`,
+  digital handbrake = `BTN_THUMB2`, analog handbrake = `ABS_Z`, all hardware-mapped
+  on an RS50. Added `wheel_handbrake_curve` and `wheel_handbrake_sensitivity` to
+  shape the analog handbrake (base `0x80A4` axis 4), the same curve type as the
+  pedals, verified live. Wired into logi-dd.
 - **Hardware pedal shaping.** The pedal unit (HID++ sub-device `0x02`) applies a
   `0x80A4` response curve to each axis it reports to the PC, the same mechanism
   as the steering wheel. Verified on an RS50 for all three pedals with an

--- a/README.md
+++ b/README.md
@@ -560,9 +560,15 @@ one curve the axis holds (last write wins):
 | `wheel_<p>_curve` | `reset` or `in:out` pairs | Full response curve (like `wheel_response_curve`) |
 | `wheel_<p>_sensitivity` | 0-100 (50=linear) | G HUB sensitivity slider |
 | `wheel_<p>_deadzone` | `"lower upper"` % | Dead travel at each end (sum ≤ 99) |
+| `wheel_combined_pedals` | 0-1 | Merge throttle+brake into one axis (legacy games; desktop only) |
 
 The `logi-dd` app has a G HUB-style point editor for these curves. See
 `docs/SYSFS_API.md` for the complete reference with examples.
+
+The **RS Shifter & Handbrake** accessory works with no extra setup: plugged
+into the wheel base, its inputs ride the wheel's existing report (sequential
+shift = paddle buttons, digital handbrake = a face button, analog handbrake =
+an axis, `ABS_Z` on the RS50).
 
 ### Oversteer Compatibility
 

--- a/README.md
+++ b/README.md
@@ -568,7 +568,9 @@ The `logi-dd` app has a G HUB-style point editor for these curves. See
 The **RS Shifter & Handbrake** accessory works with no extra setup: plugged
 into the wheel base, its inputs ride the wheel's existing report (sequential
 shift = paddle buttons, digital handbrake = a face button, analog handbrake =
-an axis, `ABS_Z` on the RS50).
+an axis, `ABS_Z` on the RS50). The analog handbrake can be shaped like the
+pedals via `wheel_handbrake_curve` / `wheel_handbrake_sensitivity`. See
+`docs/SYSFS_API.md` for the full input mapping.
 
 ### Oversteer Compatibility
 

--- a/docs/SYSFS_API.md
+++ b/docs/SYSFS_API.md
@@ -796,6 +796,37 @@ echo 0 > wheel_combined_pedals   # separate (default)
 cat wheel_combined_pedals        # 0 or 1
 ```
 
+### wheel_handbrake_curve / wheel_handbrake_sensitivity
+
+Response-curve shaping for the **RS Shifter & Handbrake** in analog handbrake
+mode. The handbrake drives a base axis (`0x80A4` axis 4, evdev `ABS_Z`), and the
+driver shapes it with the same mechanism as the pedals, verified on an RS50.
+
+- `wheel_handbrake_curve` - raw `in:out` points or `reset`, like `wheel_response_curve`.
+- `wheel_handbrake_sensitivity` - the 0-100 G HUB slider (50 = linear).
+
+Both write the one curve the axis holds; last write wins. The handbrake *input*
+itself needs no configuration: connected to the wheel base, it works out of the
+box as `ABS_Z`. These attributes only shape it.
+
+```bash
+echo 70 > wheel_handbrake_sensitivity
+echo "0:0 26000:0 65535:65535" > wheel_handbrake_curve   # 40% dead travel
+echo reset > wheel_handbrake_curve
+```
+
+### RS Shifter & Handbrake input mapping
+
+The accessory rides the wheel's existing report, so its inputs reach evdev with
+no driver change. By its mode switch:
+
+| Mode | Action | evdev |
+|------|--------|-------|
+| Sequential shifter | shift up | `BTN_TOP2` |
+| Sequential shifter | shift down | `BTN_PINKIE` |
+| Digital handbrake | pull past point | `BTN_THUMB2` (face button) |
+| Analog handbrake | pull | `ABS_Z` axis |
+
 ---
 
 ## Compatibility Attributes

--- a/docs/SYSFS_API.md
+++ b/docs/SYSFS_API.md
@@ -779,6 +779,23 @@ echo "8 5" > wheel_clutch_deadzone
 > with a custom shape, author the whole thing as a single `_curve` upload (this
 > is what the logi-dd editor does).
 
+### wheel_combined_pedals
+**Access**: Read/Write, **Values**: `0` (separate) / `1` (combined)
+**Mode**: desktop only
+
+G HUB's "combined pedals" toggle (feature `0x80D0`). When on, the wheel merges
+the throttle and brake into a single centred axis for legacy games that expect
+one pedal axis: released = centre, one pedal drives it up, the other down. The
+brake's own axis goes silent. Off for any modern sim. Verified on an RS50: with
+it on, `ABS_RX` re-centres to ~32768 and `ABS_RY` (the separate brake axis)
+stops reporting.
+
+```bash
+echo 1 > wheel_combined_pedals   # merge (legacy games)
+echo 0 > wheel_combined_pedals   # separate (default)
+cat wheel_combined_pedals        # 0 or 1
+```
+
 ---
 
 ## Compatibility Attributes

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -4477,7 +4477,7 @@ struct hidpp_dd_ff_data {
 	u8 rev_target;			/* newest requested level, WRITE_ONCE/READ_ONCE */
 	unsigned long rev_last_write;	/* jiffies of last level-pair attempt (rev_lock) */
 	u8 idx_profile;			/* Feature index for Profile switching */
-	u8 idx_profile_notify;		/* Feature index for profile-change broadcasts (0x80D0) */
+	u8 idx_profile_notify;		/* Feature index for 0x80D0 (dual-purpose: profile-change broadcasts AND the combined-pedals get/set fn0/fn1) */
 	u8 idx_sync;			/* Feature index for sync/prepare (0x1BC0) */
 	u8 idx_calibrate;		/* Feature index for centre calibration (G Pro sub-device 0x05, page 0x812C) */
 	u8 calibrate_dev_idx;		/* HID++ device index used for calibrate sends (0x05 on G Pro) */
@@ -11047,6 +11047,75 @@ static DEVICE_ATTR(wheel_response_curve, 0664, wheel_response_curve_show,
 		   wheel_response_curve_store);
 
 /*
+ * Combined pedals (feature 0x80D0 on the wheel base). G Hub's "Kombinerade
+ * pedaler" toggle: it merges the throttle and brake into a single split axis
+ * for legacy games that expect one pedal axis. Off for modern sims. Protocol
+ * from the 2026-07-14 capture: fn1 sets the boolean (`10 ff 0e 1a 01` on /
+ * `...00` off); fn0 reads it back. Desktop mode only, like the other host-side
+ * transforms.
+ */
+static ssize_t wheel_combined_pedals_show(struct device *dev,
+					  struct device_attribute *attr,
+					  char *buf)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	struct hidpp_report response;
+	int ret;
+
+	if (!hidpp)
+		return -ENODEV;
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping))
+		return -ENODEV;
+	if (ff->idx_profile_notify == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;
+
+	memset(&response, 0, sizeof(response));
+	ret = hidpp_send_fap_command_sync(hidpp, ff->idx_profile_notify,
+					  0x00 /* fn0 get */, NULL, 0, &response);
+	if (ret)
+		return hidpp_errno(hid, ret, "read combined pedals");
+	return sysfs_emit(buf, "%u\n", response.fap.params[0] ? 1 : 0);
+}
+
+static ssize_t wheel_combined_pedals_store(struct device *dev,
+					   struct device_attribute *attr,
+					   const char *buf, size_t count)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	struct hidpp_report response;
+	bool on;
+	u8 params[1];
+	int ret;
+
+	if (!hidpp)
+		return -ENODEV;
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping))
+		return -ENODEV;
+	if (ff->idx_profile_notify == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;
+	if (kstrtobool(buf, &on))
+		return -EINVAL;
+
+	params[0] = on ? 1 : 0;
+	memset(&response, 0, sizeof(response));
+	ret = hidpp_send_fap_command_sync(hidpp, ff->idx_profile_notify,
+					  0x10 /* fn1 set */, params, 1,
+					  &response);
+	if (ret)
+		return hidpp_errno(hid, ret, "set combined pedals");
+	dd_info(hid, "Combined pedals %s\n", on ? "enabled" : "disabled");
+	return count;
+}
+static DEVICE_ATTR(wheel_combined_pedals, 0664, wheel_combined_pedals_show,
+		   wheel_combined_pedals_store);
+
+/*
  * Pedal shaping: 0x80A4 response curves on the pedal sub-device (0x02), axes
  * 0=throttle, 1=brake, 2=clutch. Hardware-verified 2026-07-16 that the pedal
  * MCU applies an uploaded curve to its PC HID output (double-plateau test).
@@ -11516,6 +11585,7 @@ static struct attribute *hidpp_dd_wheel_group_attrs[] = {
 	&dev_attr_wheel_profile_names.attr,
 	&dev_attr_wheel_range_restore.attr,
 	&dev_attr_wheel_response_curve.attr,
+	&dev_attr_wheel_combined_pedals.attr,
 	&dev_attr_wheel_throttle_curve.attr,
 	&dev_attr_wheel_throttle_sensitivity.attr,
 	&dev_attr_wheel_throttle_deadzone.attr,

--- a/mainline/hid-logitech-hidpp.c
+++ b/mainline/hid-logitech-hidpp.c
@@ -4235,6 +4235,7 @@ static void hidpp_ff_retry_work(struct work_struct *work)
 #define HIDPP_DD_PAGE_FILTER		0x8140	/* FFB Filter */
 #define HIDPP_DD_PAGE_RESPONSE_CURVE	0x80A4	/* Per-axis 64-point response curves */
 #define HIDPP_DD_PEDAL_DEV_IDX		0x02	/* HID++ sub-device index of the pedal unit (0x80A4 axis curves) */
+#define HIDPP_DD_HANDBRAKE_AXIS		4	/* 0x80A4 axis on the base (dev 0xff) for the RS handbrake (HID usage 0x32 = Z) */
 #define HIDPP_DD_PAGE_CALIBRATE		0x812C	/* Centre calibration (G Pro sub-device 0x05) */
 #define HIDPP_DD_PAGE_SYNC			0x1BC0	/* Unknown sync/prepare feature */
 
@@ -4515,6 +4516,7 @@ struct hidpp_dd_ff_data {
 	 */
 	u8 pedal_sens[3];
 	u8 pedal_deadzone[3][2];		/* [axis][0]=lower %, [axis][1]=upper % */
+	u8 handbrake_sens;		/* Last handbrake sensitivity written (0-100, 50=linear); base 0x80A4 axis 4 */
 
 	/* Wheel settings (sysfs configurable) */
 	u16 range;			/* rotation range in degrees */
@@ -6768,6 +6770,7 @@ static void hidpp_dd_discover_settings_features(struct hidpp_dd_ff_data *ff)
 	 * would claim shaping the axis no longer has.
 	 */
 	ff->pedal_sens[0] = ff->pedal_sens[1] = ff->pedal_sens[2] = 50;
+	ff->handbrake_sens = 50;
 	memset(ff->pedal_deadzone, 0, sizeof(ff->pedal_deadzone));
 	ff->idx_brightness = HIDPP_DD_FEATURE_NOT_FOUND;
 	ff->idx_profile = HIDPP_DD_FEATURE_NOT_FOUND;
@@ -11116,6 +11119,146 @@ static DEVICE_ATTR(wheel_combined_pedals, 0664, wheel_combined_pedals_show,
 		   wheel_combined_pedals_store);
 
 /*
+ * Handbrake shaping. The RS Shifter & Handbrake, in analog handbrake mode,
+ * drives a base axis (0x80A4 axis 4, HID usage 0x32 = Z, evdev ABS_Z). Unlike
+ * the pedals (which shape on the pedal MCU), the handbrake shapes on the wheel
+ * base, verified 2026-07-16. Two generators, both writing the one curve the
+ * axis holds: _curve (raw points) and _sensitivity (the G Hub slider). The
+ * input itself needs no driver help; these only shape it.
+ */
+static ssize_t wheel_handbrake_curve_show(struct device *dev,
+					  struct device_attribute *attr,
+					  char *buf)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	struct hidpp_report response;
+	u8 params[1] = { HIDPP_DD_HANDBRAKE_AXIS };
+	u16 loaded, max;
+	int ret;
+
+	if (!hidpp)
+		return -ENODEV;
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping))
+		return -ENODEV;
+	if (ff->idx_response_curve == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;
+
+	memset(&response, 0, sizeof(response));
+	ret = hidpp_send_fap_command_sync(hidpp, ff->idx_response_curve,
+					  0x10 /* fn1 axis info */, params, 1,
+					  &response);
+	if (ret)
+		return hidpp_errno(hid, ret, "read handbrake curve info");
+	loaded = get_unaligned_be16(&response.fap.params[6]);
+	max = get_unaligned_be16(&response.fap.params[8]);
+	return sysfs_emit(buf, "%u/%u points loaded (0 = built-in curve)\n",
+			  loaded, max);
+}
+
+static ssize_t wheel_handbrake_curve_store(struct device *dev,
+					   struct device_attribute *attr,
+					   const char *buf, size_t count)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	int ret;
+
+	if (!hidpp)
+		return -ENODEV;
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping))
+		return -ENODEV;
+	if (ff->idx_response_curve == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;
+
+	if (sysfs_streq(buf, "reset")) {
+		ret = hidpp_dd_response_curve_revert(hidpp, 0xff,
+						     HIDPP_DD_HANDBRAKE_AXIS,
+						     ff->idx_response_curve);
+		return ret ? hidpp_errno(hid, ret, "reset handbrake curve") : count;
+	}
+	ret = hidpp_dd_response_curve_upload(hidpp, ff, 0xff,
+					     HIDPP_DD_HANDBRAKE_AXIS,
+					     ff->idx_response_curve, buf, count);
+	return ret < 0 ? ret : count;
+}
+static DEVICE_ATTR(wheel_handbrake_curve, 0664, wheel_handbrake_curve_show,
+		   wheel_handbrake_curve_store);
+
+static ssize_t wheel_handbrake_sensitivity_show(struct device *dev,
+						struct device_attribute *attr,
+						char *buf)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+
+	if (!hidpp)
+		return -ENODEV;
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping))
+		return -ENODEV;
+	if (ff->idx_response_curve == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;
+	return sysfs_emit(buf, "%u\n", ff->handbrake_sens);
+}
+
+static ssize_t wheel_handbrake_sensitivity_store(struct device *dev,
+						 struct device_attribute *attr,
+						 const char *buf, size_t count)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct hidpp_device *hidpp = hid_get_drvdata(hid);
+	struct hidpp_dd_ff_data *ff;
+	int sensitivity, ret;
+	size_t len;
+	char *curve;
+
+	if (!hidpp)
+		return -ENODEV;
+	ff = READ_ONCE(hidpp->private_data);
+	if (!ff || atomic_read_acquire(&ff->stopping))
+		return -ENODEV;
+	if (ff->idx_response_curve == HIDPP_DD_FEATURE_NOT_FOUND)
+		return -EOPNOTSUPP;
+	ret = kstrtoint(buf, 10, &sensitivity);
+	if (ret)
+		return ret;
+	sensitivity = clamp(sensitivity, 0, 100);
+
+	if (sensitivity == 50) {
+		ret = hidpp_dd_response_curve_revert(hidpp, 0xff,
+						     HIDPP_DD_HANDBRAKE_AXIS,
+						     ff->idx_response_curve);
+		if (ret)
+			return hidpp_errno(hid, ret, "set handbrake sensitivity");
+		ff->handbrake_sens = 50;
+		return count;
+	}
+
+	curve = kmalloc(HIDPP_DD_SENS_CURVE_BUFSZ, GFP_KERNEL);
+	if (!curve)
+		return -ENOMEM;
+	len = hidpp_dd_build_sensitivity_curve(sensitivity, curve,
+					       HIDPP_DD_SENS_CURVE_BUFSZ);
+	ret = hidpp_dd_response_curve_upload(hidpp, ff, 0xff,
+					     HIDPP_DD_HANDBRAKE_AXIS,
+					     ff->idx_response_curve, curve, len);
+	kfree(curve);
+	if (ret)
+		return ret;
+	ff->handbrake_sens = sensitivity;
+	return count;
+}
+static DEVICE_ATTR(wheel_handbrake_sensitivity, 0664,
+		   wheel_handbrake_sensitivity_show,
+		   wheel_handbrake_sensitivity_store);
+
+/*
  * Pedal shaping: 0x80A4 response curves on the pedal sub-device (0x02), axes
  * 0=throttle, 1=brake, 2=clutch. Hardware-verified 2026-07-16 that the pedal
  * MCU applies an uploaded curve to its PC HID output (double-plateau test).
@@ -11586,6 +11729,8 @@ static struct attribute *hidpp_dd_wheel_group_attrs[] = {
 	&dev_attr_wheel_range_restore.attr,
 	&dev_attr_wheel_response_curve.attr,
 	&dev_attr_wheel_combined_pedals.attr,
+	&dev_attr_wheel_handbrake_curve.attr,
+	&dev_attr_wheel_handbrake_sensitivity.attr,
 	&dev_attr_wheel_throttle_curve.attr,
 	&dev_attr_wheel_throttle_sensitivity.attr,
 	&dev_attr_wheel_throttle_deadzone.attr,

--- a/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
@@ -33,6 +33,7 @@ pub const REGISTRY: &[SettingSpec] = &[
     // wins; the curve attr reads back the true device state. mode_req Any: the
     // driver's pedal stores do not gate on mode.
     SettingSpec { attr: "wheel_brake_force", label: "Brake force", help: "Load-cell brake threshold (0-100%). Onboard mode only.", category: Pedals, kind: PCT, access: ReadWrite, mode_req: OnboardOnly },
+    SettingSpec { attr: "wheel_combined_pedals", label: "Combined pedals", help: "Merge throttle+brake into one axis for legacy games. Off for modern sims. Desktop mode only.", category: Pedals, kind: Kind::Toggle { off: "separate", on: "combined" }, access: ReadWrite, mode_req: DesktopOnly },
     SettingSpec { attr: "wheel_throttle_curve", label: "Throttle curve", help: "Full throttle response curve. 'reset' for built-in.", category: Pedals, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_throttle_sensitivity", label: "Throttle sensitivity", help: "Throttle response (0-100, 50=linear).", category: Pedals, kind: PCT, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_throttle_deadzone", label: "Throttle deadzone", help: "Dead travel 'lower upper' percent (sum <= 99).", category: Pedals, kind: Kind::Pair { max: 99 }, access: ReadWrite, mode_req: Any },

--- a/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
+++ b/userspace/logi-dd/crates/logi-dd-core/src/registry.rs
@@ -34,6 +34,11 @@ pub const REGISTRY: &[SettingSpec] = &[
     // driver's pedal stores do not gate on mode.
     SettingSpec { attr: "wheel_brake_force", label: "Brake force", help: "Load-cell brake threshold (0-100%). Onboard mode only.", category: Pedals, kind: PCT, access: ReadWrite, mode_req: OnboardOnly },
     SettingSpec { attr: "wheel_combined_pedals", label: "Combined pedals", help: "Merge throttle+brake into one axis for legacy games. Off for modern sims. Desktop mode only.", category: Pedals, kind: Kind::Toggle { off: "separate", on: "combined" }, access: ReadWrite, mode_req: DesktopOnly },
+    // RS Shifter & Handbrake accessory (analog handbrake axis shaping). Only
+    // present when the handbrake is connected; the row reads unavailable
+    // otherwise. Same 0x80A4 curve type as the pedals, on the wheel base.
+    SettingSpec { attr: "wheel_handbrake_curve", label: "Handbrake curve", help: "Full handbrake response curve. 'reset' for built-in.", category: Pedals, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
+    SettingSpec { attr: "wheel_handbrake_sensitivity", label: "Handbrake sensitivity", help: "Handbrake response (0-100, 50=linear).", category: Pedals, kind: PCT, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_throttle_curve", label: "Throttle curve", help: "Full throttle response curve. 'reset' for built-in.", category: Pedals, kind: Kind::Curve, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_throttle_sensitivity", label: "Throttle sensitivity", help: "Throttle response (0-100, 50=linear).", category: Pedals, kind: PCT, access: ReadWrite, mode_req: Any },
     SettingSpec { attr: "wheel_throttle_deadzone", label: "Throttle deadzone", help: "Dead travel 'lower upper' percent (sum <= 99).", category: Pedals, kind: Kind::Pair { max: 99 }, access: ReadWrite, mode_req: Any },


### PR DESCRIPTION
Adds combined pedals and full RS Shifter & Handbrake support, all hardware-validated on an RS50.

## Combined pedals
`wheel_combined_pedals` (0/1, desktop only) toggles G HUB's legacy throttle+brake axis merge via feature `0x80D0` (fn0 get / fn1 set). Verified: on, the pedals collapse to a single centred axis (`ABS_RX` re-centres to ~32768, `ABS_RY` goes silent); off restores separate axes.

## RS Shifter & Handbrake
Every mode works with **no driver change** (inputs ride the wheel's existing interface-0 report), hardware-mapped:

| Mode | Action | evdev |
|------|--------|-------|
| Sequential shifter | up / down | `BTN_TOP2` / `BTN_PINKIE` |
| Digital handbrake | pull past point | `BTN_THUMB2` |
| Analog handbrake | pull | `ABS_Z` |

The analog handbrake is shapeable like the pedals via `wheel_handbrake_curve` / `wheel_handbrake_sensitivity` (base `0x80A4` axis 4, HID usage 0x32 = Z). Verified: a step curve on axis 4 shapes `ABS_Z` (bimodal, forbidden band 0.4%).

## Notes
- Combined pedals reuses the feature the driver already discovers as `idx_profile_notify` (0x80D0 is dual-purpose).
- Handbrake shaping reuses the steering curve index + the sensitivity Bezier.
- All wired into logi-dd; input mapping + attributes documented in SYSFS_API.
- 39 core + 35 TUI tests, driver builds clean.
