### PR TITLE
fix(logi-wheel): match the G PRO's real evdev name in the Test view

### DIFF
--- a/userspace/logi-wheel/crates/logi-wheel-core/src/evtest.rs
+++ b/userspace/logi-wheel/crates/logi-wheel-core/src/evtest.rs
@@ -358,8 +358,10 @@ pub fn hat_label(x: i32, y: i32) -> &'static str {
 /// ffb-proxy crate uses for its own discovery.
 pub fn is_wheel_name(name: &str) -> bool {
     let upper = name.to_uppercase();
-    let looks_like_wheel =
-        upper.contains("RS50") || upper.contains("G PRO") || upper.contains("G923");
+    let looks_like_wheel = upper.contains("RS50")
+        || upper.contains("PRO RACING WHEEL")
+        || upper.contains("G PRO")
+        || upper.contains("G923");
     let excluded = upper.contains("CONSUMER CONTROL")
         || upper.contains("KEYBOARD")
         || upper.contains("MOUSE")
@@ -647,6 +649,8 @@ mod tests {
     fn wheel_name_heuristic_matches_ffb_proxys() {
         assert!(is_wheel_name("Logitech RS50 Base for PlayStation/PC"));
         assert!(is_wheel_name("Logitech G PRO Racing Wheel"));
+        assert!(is_wheel_name("Logitech  PRO Racing Wheel"));
+        assert!(is_wheel_name("PRO Racing Wheel"));
         assert!(is_wheel_name("Logitech G923 Racing Wheel"));
         assert!(!is_wheel_name("Logi Litra Glow Consumer Control"));
         assert!(!is_wheel_name("RS50 Wireless Keyboard"));


### PR DESCRIPTION
current logi-wheel don't detect my Pro Racing Wheel at evdev level.

is_wheel_name() accepted "RS50", "G PRO" or "G923", but a real G PRO Racing Wheel does not report "G PRO" anywhere: its USB product string is "PRO Racing Wheel"

the evdev node is named "Logitech  PRO Racing Wheel" with two spaces